### PR TITLE
Add UDP proxy component for bridging between AP and STA networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ substitutions:
   mqtt_username: ""
   mqtt_password: ""
   mqtt_topic_prefix: "marsrelay"
+  udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.
     enabled: true
@@ -111,7 +112,7 @@ capture_dns:
   id: capture_dns_server
 
 udp_proxy:
-  - port: 1010
+  - port: ${udp_proxy_port}
 
 mqtt:
   id: mqtt_client

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ wifi:
 capture_dns:
   id: capture_dns_server
 
+udp_proxy:
+  - port: 1010
+
 mqtt:
   id: mqtt_client
   broker: ${mqtt_broker}
@@ -216,6 +219,7 @@ This repository contains ESPHome external components for building Marsrelay:
 - **`mosquitto_broker`**: An embedded MQTT broker that forwards messages from Marstek devices to your main MQTT broker
 - **`marstack`**: A web server component that implements Marstek's API endpoints
 - **`capture_dns`**: DNS redirection component that intercepts DNS queries and redirects them to the device
+- **`udp_proxy`**: UDP proxy component that bridges UDP broadcasts between the AP network (where Marstek devices connect) and the STA network (your home network). This enables zero feed-in control by forwarding UDP discovery/control packets between networks. Supports multiple ports.
 - **`wifi`**: Patched WiFi component to support simultaneous access point while station mode is enabled
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ substitutions:
   mqtt_username: ""
   mqtt_password: ""
   mqtt_topic_prefix: "marsrelay"
-  # UDP proxy port for Shelly power meter discovery (see https://github.com/tomquist/b2500-meter)
-  # Only needed for Shelly device emulation (not CT001/CT002 which use TCP):
+  # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
+  # - Port 2222: Shelly 3EM gen3
+  # - Port 2223: Shelly Pro EM50
+  # - Port 12345: CT001/CT002/CT003
   udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ substitutions:
   mqtt_username: ""
   mqtt_password: ""
   mqtt_topic_prefix: "marsrelay"
+  # UDP proxy port for power meter emulation (see https://github.com/tomquist/b2500-meter)
+  # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
+  # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.
@@ -111,6 +114,8 @@ wifi:
 capture_dns:
   id: capture_dns_server
 
+# UDP proxy bridges broadcasts between AP and STA networks for power meter discovery
+# Add multiple entries if you need to support different firmware versions
 udp_proxy:
   - port: ${udp_proxy_port}
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ substitutions:
   mqtt_username: ""
   mqtt_password: ""
   mqtt_topic_prefix: "marsrelay"
-  # UDP proxy port for power meter emulation (see https://github.com/tomquist/b2500-meter)
+  # UDP proxy port for Shelly power meter discovery (see https://github.com/tomquist/b2500-meter)
+  # Only needed for Shelly device emulation (not CT001/CT002 which use TCP):
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   udp_proxy_port: "1010"

--- a/components/udp_proxy/__init__.py
+++ b/components/udp_proxy/__init__.py
@@ -1,0 +1,90 @@
+import esphome.codegen as cg
+from esphome.config_helpers import filter_source_files_from_platform
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PORT,
+    PLATFORM_ESP32,
+    PlatformFramework,
+)
+from esphome.core import CORE, coroutine_with_priority
+from esphome.coroutine import CoroPriority
+import esphome.final_validate as fv
+from esphome.types import ConfigType
+
+
+def AUTO_LOAD() -> list[str]:
+    auto_load = []
+    if CORE.is_esp32:
+        auto_load.append("socket")
+    return auto_load
+
+
+DEPENDENCIES = ["wifi"]
+CODEOWNERS = ["@marsrelay"]
+
+CONF_SESSION_TIMEOUT = "session_timeout"
+
+udp_proxy_ns = cg.esphome_ns.namespace("udp_proxy")
+UdpProxy = udp_proxy_ns.class_("UdpProxy", cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(UdpProxy),
+            cv.Required(CONF_PORT): cv.port,
+            cv.Optional(CONF_SESSION_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on([PLATFORM_ESP32]),
+)
+
+
+def _final_validate(config: ConfigType) -> ConfigType:
+    full_config = fv.full_config.get()
+    wifi_conf = full_config.get("wifi")
+
+    if wifi_conf is None:
+        raise cv.Invalid("UDP proxy requires the wifi component to be configured")
+
+    if "ap" not in wifi_conf:
+        raise cv.Invalid(
+            "UDP proxy requires a WiFi AP to be configured. "
+            "Add 'ap:' to your WiFi configuration."
+        )
+
+    if "ssid" not in wifi_conf and "networks" not in wifi_conf:
+        raise cv.Invalid(
+            "UDP proxy requires a WiFi STA connection (ssid or networks). "
+            "The proxy bridges between AP and STA networks."
+        )
+
+    if CORE.is_esp32:
+        from esphome.components import socket
+
+        # We use 2 sockets: one for AP listening, one for STA forwarding
+        socket.consume_sockets(2, "udp_proxy")(config)
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
+
+
+@coroutine_with_priority(CoroPriority.CAPTIVE_PORTAL)
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    cg.add_define("USE_UDP_PROXY")
+
+    cg.add(var.set_port(config[CONF_PORT]))
+    cg.add(var.set_session_timeout(config[CONF_SESSION_TIMEOUT]))
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "udp_proxy.cpp": {
+            PlatformFramework.ESP32_IDF,
+        },
+    }
+)

--- a/components/udp_proxy/__init__.py
+++ b/components/udp_proxy/__init__.py
@@ -22,6 +22,7 @@ def AUTO_LOAD() -> list[str]:
 
 DEPENDENCIES = ["wifi"]
 CODEOWNERS = ["@marsrelay"]
+MULTI_CONF = True
 
 CONF_SESSION_TIMEOUT = "session_timeout"
 

--- a/components/udp_proxy/udp_proxy.cpp
+++ b/components/udp_proxy/udp_proxy.cpp
@@ -37,7 +37,8 @@ network::IPAddress UdpProxy::get_ap_ip() {
 }
 
 network::IPAddress UdpProxy::get_sta_ip() {
-  return wifi::global_wifi_component->wifi_sta_ip();
+  network::IPAddresses addresses = wifi::global_wifi_component->get_ip_addresses();
+  return addresses[0];
 }
 
 bool UdpProxy::is_ap_network(const network::IPAddress &ip) {

--- a/components/udp_proxy/udp_proxy.cpp
+++ b/components/udp_proxy/udp_proxy.cpp
@@ -1,0 +1,347 @@
+#include "udp_proxy.h"
+
+#ifdef USE_UDP_PROXY
+
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/wifi/wifi_component.h"
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
+#include <lwip/igmp.h>
+#include <esp_netif.h>
+#include <cstring>
+
+namespace esphome {
+namespace udp_proxy {
+
+static const char *const TAG = "udp_proxy";
+
+void UdpProxy::setup() {
+  this->start();
+}
+
+float UdpProxy::get_setup_priority() const {
+  // After WiFi
+  return setup_priority::WIFI - 1.0f;
+}
+
+void UdpProxy::dump_config() {
+  ESP_LOGCONFIG(TAG, "UDP Proxy:");
+  ESP_LOGCONFIG(TAG, "  Port: %d", this->port_);
+  ESP_LOGCONFIG(TAG, "  Session Timeout: %d ms", this->session_timeout_ms_);
+  ESP_LOGCONFIG(TAG, "  Active: %s", this->active_ ? "Yes" : "No");
+}
+
+network::IPAddress UdpProxy::get_ap_ip() {
+  return wifi::global_wifi_component->wifi_soft_ap_ip();
+}
+
+network::IPAddress UdpProxy::get_sta_ip() {
+  return wifi::global_wifi_component->wifi_sta_ip();
+}
+
+bool UdpProxy::is_ap_network(const network::IPAddress &ip) {
+  // Check if the IP is in the AP subnet (typically 192.168.4.x)
+  network::IPAddress ap_ip = this->get_ap_ip();
+
+  // Compare first 3 octets (assuming /24 subnet)
+  // For IPv4, we can compare the network portion
+  ip4_addr_t ap_addr = ap_ip;
+  ip4_addr_t check_addr = ip;
+
+  // Mask for /24 network in network byte order
+  // 255.255.255.0 = 0xFFFFFF00 in host order, need htonl to convert to network order
+  uint32_t mask = htonl(0xFFFFFF00);
+  return (ap_addr.addr & mask) == (check_addr.addr & mask);
+}
+
+void UdpProxy::start() {
+  if (this->active_) {
+    ESP_LOGW(TAG, "UDP proxy already active");
+    return;
+  }
+
+  if (this->port_ == 0) {
+    ESP_LOGE(TAG, "No port configured for UDP proxy");
+    return;
+  }
+
+  // Wait for both AP and STA to be ready
+  network::IPAddress ap_ip = this->get_ap_ip();
+  network::IPAddress sta_ip = this->get_sta_ip();
+
+  char ap_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  char sta_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+
+  ESP_LOGI(TAG, "Starting UDP proxy on port %d", this->port_);
+  ESP_LOGI(TAG, "  AP IP: %s", ap_ip.str_to(ap_ip_buf));
+  ESP_LOGI(TAG, "  STA IP: %s", sta_ip.str_to(sta_ip_buf));
+
+  // Create AP-side socket - this receives broadcasts from Marstek device
+  this->ap_socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+  if (this->ap_socket_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create AP-side UDP socket");
+    return;
+  }
+
+  int enable = 1;
+  this->ap_socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+  this->ap_socket_->setsockopt(SOL_SOCKET, SO_BROADCAST, &enable, sizeof(enable));
+
+  // Bind to all interfaces on the target port
+  // We'll filter by source IP to determine which network the packet came from
+  struct sockaddr_storage ap_addr = {};
+  socklen_t ap_addr_len = socket::set_sockaddr_any((struct sockaddr *) &ap_addr, sizeof(ap_addr), this->port_);
+
+  int err = this->ap_socket_->bind((struct sockaddr *) &ap_addr, ap_addr_len);
+  if (err != 0) {
+    ESP_LOGE(TAG, "Failed to bind AP socket to port %d: %d (%s)", this->port_, errno, strerror(errno));
+    this->ap_socket_ = nullptr;
+    return;
+  }
+
+  ESP_LOGI(TAG, "AP socket bound to port %d", this->port_);
+
+  // Create STA-side socket - this forwards to home network and receives responses
+  this->sta_socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+  if (this->sta_socket_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create STA-side UDP socket");
+    this->ap_socket_->close();
+    this->ap_socket_ = nullptr;
+    return;
+  }
+
+  this->sta_socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+  this->sta_socket_->setsockopt(SOL_SOCKET, SO_BROADCAST, &enable, sizeof(enable));
+
+  // Bind to any available port on STA interface for outgoing traffic
+  // We bind to port 0 to let the system assign a port
+  struct sockaddr_storage sta_addr = {};
+  socklen_t sta_addr_len = socket::set_sockaddr_any((struct sockaddr *) &sta_addr, sizeof(sta_addr), 0);
+
+  err = this->sta_socket_->bind((struct sockaddr *) &sta_addr, sta_addr_len);
+  if (err != 0) {
+    ESP_LOGE(TAG, "Failed to bind STA socket: %d (%s)", errno, strerror(errno));
+    this->ap_socket_->close();
+    this->ap_socket_ = nullptr;
+    this->sta_socket_ = nullptr;
+    return;
+  }
+
+  // Get the assigned port for logging
+  struct sockaddr_in local_addr;
+  socklen_t local_addr_len = sizeof(local_addr);
+  getsockname(this->sta_socket_->get_fd(), (struct sockaddr *) &local_addr, &local_addr_len);
+  ESP_LOGI(TAG, "STA socket bound to port %d", ntohs(local_addr.sin_port));
+
+  this->active_ = true;
+  ESP_LOGI(TAG, "UDP proxy started successfully");
+}
+
+void UdpProxy::stop() {
+  if (!this->active_) {
+    return;
+  }
+
+  this->active_ = false;
+
+  if (this->ap_socket_ != nullptr) {
+    this->ap_socket_->close();
+    this->ap_socket_ = nullptr;
+  }
+
+  if (this->sta_socket_ != nullptr) {
+    this->sta_socket_->close();
+    this->sta_socket_ = nullptr;
+  }
+
+  this->sessions_.clear();
+  ESP_LOGI(TAG, "UDP proxy stopped");
+}
+
+void UdpProxy::loop() {
+  if (!this->active_) {
+    return;
+  }
+
+  // Process incoming packets on both sockets
+  this->process_ap_socket();
+  this->process_sta_socket();
+
+  // Cleanup expired sessions periodically (every 5 seconds)
+  uint32_t now = millis();
+  if (now - this->last_cleanup_ > 5000) {
+    this->cleanup_expired_sessions();
+    this->last_cleanup_ = now;
+  }
+}
+
+void UdpProxy::process_ap_socket() {
+  if (this->ap_socket_ == nullptr || !this->ap_socket_->ready()) {
+    return;
+  }
+
+  int fd = this->ap_socket_->get_fd();
+  if (fd < 0) {
+    return;
+  }
+
+  struct sockaddr_in client_addr;
+  socklen_t client_addr_len = sizeof(client_addr);
+
+  ssize_t len = recvfrom(fd, this->buffer_, sizeof(this->buffer_), MSG_DONTWAIT,
+                         (struct sockaddr *) &client_addr, &client_addr_len);
+
+  if (len < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+      ESP_LOGE(TAG, "AP socket recvfrom failed: %d (%s)", errno, strerror(errno));
+    }
+    return;
+  }
+
+  if (len == 0) {
+    return;
+  }
+
+  network::IPAddress src_ip;
+  src_ip = client_addr.sin_addr.s_addr;
+  uint16_t src_port = ntohs(client_addr.sin_port);
+
+  char src_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  ESP_LOGD(TAG, "Received %d bytes on AP socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
+
+  // Check if this is from the AP network (our target)
+  if (!this->is_ap_network(src_ip)) {
+    ESP_LOGV(TAG, "Ignoring packet from non-AP network");
+    return;
+  }
+
+  // Store/update session for this client
+  // Key by source port since that's what we need to route responses back to
+  UdpSession session;
+  session.client_ip = src_ip;
+  session.client_port = src_port;
+  session.last_activity = millis();
+  this->sessions_[src_port] = session;
+
+  ESP_LOGD(TAG, "Session created/updated for %s:%d", src_ip_buf, src_port);
+
+  // Forward to STA network as broadcast
+  if (this->sta_socket_ == nullptr) {
+    ESP_LOGW(TAG, "STA socket not available, cannot forward");
+    return;
+  }
+
+  // Create broadcast address for STA network
+  struct sockaddr_in broadcast_addr;
+  memset(&broadcast_addr, 0, sizeof(broadcast_addr));
+  broadcast_addr.sin_family = AF_INET;
+  broadcast_addr.sin_port = htons(this->port_);
+  broadcast_addr.sin_addr.s_addr = INADDR_BROADCAST;  // 255.255.255.255
+
+  ssize_t sent = this->sta_socket_->sendto(this->buffer_, len, 0,
+                                            (struct sockaddr *) &broadcast_addr, sizeof(broadcast_addr));
+
+  if (sent < 0) {
+    ESP_LOGE(TAG, "Failed to forward to STA network: %d (%s)", errno, strerror(errno));
+  } else {
+    ESP_LOGD(TAG, "Forwarded %d bytes to STA network broadcast", sent);
+  }
+}
+
+void UdpProxy::process_sta_socket() {
+  if (this->sta_socket_ == nullptr || !this->sta_socket_->ready()) {
+    return;
+  }
+
+  int fd = this->sta_socket_->get_fd();
+  if (fd < 0) {
+    return;
+  }
+
+  struct sockaddr_in sender_addr;
+  socklen_t sender_addr_len = sizeof(sender_addr);
+
+  ssize_t len = recvfrom(fd, this->buffer_, sizeof(this->buffer_), MSG_DONTWAIT,
+                         (struct sockaddr *) &sender_addr, &sender_addr_len);
+
+  if (len < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+      ESP_LOGE(TAG, "STA socket recvfrom failed: %d (%s)", errno, strerror(errno));
+    }
+    return;
+  }
+
+  if (len == 0) {
+    return;
+  }
+
+  network::IPAddress src_ip;
+  src_ip = sender_addr.sin_addr.s_addr;
+  uint16_t src_port = ntohs(sender_addr.sin_port);
+
+  char src_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+  ESP_LOGD(TAG, "Received %d bytes on STA socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
+
+  // Forward response to all active AP clients
+  if (this->sessions_.empty()) {
+    ESP_LOGV(TAG, "No active sessions, dropping response");
+    return;
+  }
+
+  if (this->ap_socket_ == nullptr) {
+    ESP_LOGW(TAG, "AP socket not available, cannot forward response");
+    return;
+  }
+
+  int forwarded_count = 0;
+  for (auto &kv : this->sessions_) {
+    UdpSession &session = kv.second;
+
+    struct sockaddr_in client_addr;
+    memset(&client_addr, 0, sizeof(client_addr));
+    client_addr.sin_family = AF_INET;
+    client_addr.sin_port = htons(session.client_port);
+
+    ip4_addr_t addr = session.client_ip;
+    client_addr.sin_addr.s_addr = addr.addr;
+
+    char client_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    ESP_LOGD(TAG, "Forwarding response to AP client %s:%d",
+             session.client_ip.str_to(client_ip_buf), session.client_port);
+
+    ssize_t sent = this->ap_socket_->sendto(this->buffer_, len, 0,
+                                             (struct sockaddr *) &client_addr, sizeof(client_addr));
+
+    if (sent < 0) {
+      ESP_LOGE(TAG, "Failed to forward to AP client: %d (%s)", errno, strerror(errno));
+    } else {
+      forwarded_count++;
+      // Update session activity
+      session.last_activity = millis();
+    }
+  }
+
+  ESP_LOGD(TAG, "Forwarded response to %d AP client(s)", forwarded_count);
+}
+
+void UdpProxy::cleanup_expired_sessions() {
+  uint32_t now = millis();
+  auto it = this->sessions_.begin();
+
+  while (it != this->sessions_.end()) {
+    if (now - it->second.last_activity > this->session_timeout_ms_) {
+      char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+      ESP_LOGD(TAG, "Session expired for %s:%d",
+               it->second.client_ip.str_to(ip_buf), it->second.client_port);
+      it = this->sessions_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+}  // namespace udp_proxy
+}  // namespace esphome
+
+#endif  // USE_UDP_PROXY

--- a/components/udp_proxy/udp_proxy.cpp
+++ b/components/udp_proxy/udp_proxy.cpp
@@ -203,12 +203,17 @@ void UdpProxy::process_ap_socket() {
     return;
   }
 
-  network::IPAddress src_ip;
-  src_ip = client_addr.sin_addr.s_addr;
+  ip_addr_t src_ip_addr;
+  IP_ADDR4(&src_ip_addr,
+           (client_addr.sin_addr.s_addr >> 0) & 0xFF,
+           (client_addr.sin_addr.s_addr >> 8) & 0xFF,
+           (client_addr.sin_addr.s_addr >> 16) & 0xFF,
+           (client_addr.sin_addr.s_addr >> 24) & 0xFF);
+  network::IPAddress src_ip(&src_ip_addr);
   uint16_t src_port = ntohs(client_addr.sin_port);
 
   char src_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
-  ESP_LOGD(TAG, "Received %d bytes on AP socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
+  ESP_LOGD(TAG, "Received %zd bytes on AP socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
 
   // Check if this is from the AP network (our target)
   if (!this->is_ap_network(src_ip)) {
@@ -245,7 +250,7 @@ void UdpProxy::process_ap_socket() {
   if (sent < 0) {
     ESP_LOGE(TAG, "Failed to forward to STA network: %d (%s)", errno, strerror(errno));
   } else {
-    ESP_LOGD(TAG, "Forwarded %d bytes to STA network broadcast", sent);
+    ESP_LOGD(TAG, "Forwarded %zd bytes to STA network broadcast", sent);
   }
 }
 
@@ -276,12 +281,17 @@ void UdpProxy::process_sta_socket() {
     return;
   }
 
-  network::IPAddress src_ip;
-  src_ip = sender_addr.sin_addr.s_addr;
+  ip_addr_t src_ip_addr;
+  IP_ADDR4(&src_ip_addr,
+           (sender_addr.sin_addr.s_addr >> 0) & 0xFF,
+           (sender_addr.sin_addr.s_addr >> 8) & 0xFF,
+           (sender_addr.sin_addr.s_addr >> 16) & 0xFF,
+           (sender_addr.sin_addr.s_addr >> 24) & 0xFF);
+  network::IPAddress src_ip(&src_ip_addr);
   uint16_t src_port = ntohs(sender_addr.sin_port);
 
   char src_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
-  ESP_LOGD(TAG, "Received %d bytes on STA socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
+  ESP_LOGD(TAG, "Received %zd bytes on STA socket from %s:%d", len, src_ip.str_to(src_ip_buf), src_port);
 
   // Forward response to all active AP clients
   if (this->sessions_.empty()) {

--- a/components/udp_proxy/udp_proxy.h
+++ b/components/udp_proxy/udp_proxy.h
@@ -1,0 +1,91 @@
+#pragma once
+#include "esphome/core/defines.h"
+#ifdef USE_UDP_PROXY
+
+#include <memory>
+#include <map>
+#include "esphome/core/component.h"
+#include "esphome/components/socket/socket.h"
+#include "esphome/components/network/ip_address.h"
+
+namespace esphome {
+namespace udp_proxy {
+
+/// Represents an active UDP session that tracks a client's source port
+/// so responses can be routed back correctly.
+struct UdpSession {
+  /// The original client's IP address (on AP network)
+  network::IPAddress client_ip;
+  /// The original client's source port
+  uint16_t client_port;
+  /// Timestamp when this session was last active
+  uint32_t last_activity;
+};
+
+class UdpProxy : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override;
+
+  void set_port(uint16_t port) { this->port_ = port; }
+  void set_session_timeout(uint32_t timeout_ms) { this->session_timeout_ms_ = timeout_ms; }
+
+  void start();
+  void stop();
+  bool is_active() const { return this->active_; }
+
+ protected:
+  /// Process incoming packets on the AP-side socket
+  void process_ap_socket();
+
+  /// Process incoming packets on the STA-side socket
+  void process_sta_socket();
+
+  /// Clean up expired sessions
+  void cleanup_expired_sessions();
+
+  /// Check if an IP address belongs to the AP subnet
+  bool is_ap_network(const network::IPAddress &ip);
+
+  /// Get the AP network's IP address
+  network::IPAddress get_ap_ip();
+
+  /// Get the STA network's IP address
+  network::IPAddress get_sta_ip();
+
+  /// Buffer size for UDP packets
+  static constexpr size_t UDP_BUFFER_SIZE = 1500;
+
+  /// Target port to listen on and forward to
+  uint16_t port_{0};
+
+  /// Session timeout in milliseconds
+  uint32_t session_timeout_ms_{30000};
+
+  /// Whether the proxy is active
+  bool active_{false};
+
+  /// Socket listening on the AP network (receives from Marstek device)
+  std::unique_ptr<socket::Socket> ap_socket_{nullptr};
+
+  /// Socket for STA network communication (forwards to home network, receives responses)
+  std::unique_ptr<socket::Socket> sta_socket_{nullptr};
+
+  /// Map of STA-side source port to session info for routing responses back
+  /// Key is a session identifier (we use a simple incrementing counter)
+  /// In practice, since we might have multiple AP clients, we track by remote port
+  std::map<uint16_t, UdpSession> sessions_;
+
+  /// Receive buffer
+  uint8_t buffer_[UDP_BUFFER_SIZE];
+
+  /// Counter for cleanup cycle
+  uint32_t last_cleanup_{0};
+};
+
+}  // namespace udp_proxy
+}  // namespace esphome
+
+#endif  // USE_UDP_PROXY

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -55,9 +55,9 @@ capture_dns:
   id: capture_dns_server
 
 udp_proxy:
-  id: udp_bridge
-  port: 48899
-  session_timeout: 30s
+  - id: udp_bridge
+    port: 48899
+    session_timeout: 30s
 
 mqtt:
   id: mqtt_client

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -9,6 +9,9 @@ substitutions:
   mqtt_username: "mqtt_user"
   mqtt_password: "mqtt_password"
   mqtt_topic_prefix: "marsrelay"
+  # UDP proxy port for power meter emulation (see https://github.com/tomquist/b2500-meter)
+  # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
+  # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.
@@ -55,6 +58,8 @@ wifi:
 capture_dns:
   id: capture_dns_server
 
+# UDP proxy bridges broadcasts between AP and STA networks for power meter discovery
+# Add multiple entries if you need to support different firmware versions
 udp_proxy:
   - port: ${udp_proxy_port}
 

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -54,6 +54,11 @@ wifi:
 capture_dns:
   id: capture_dns_server
 
+udp_proxy:
+  id: udp_bridge
+  port: 48899
+  session_timeout: 30s
+
 mqtt:
   id: mqtt_client
   broker: ${mqtt_broker}

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -9,7 +9,8 @@ substitutions:
   mqtt_username: "mqtt_user"
   mqtt_password: "mqtt_password"
   mqtt_topic_prefix: "marsrelay"
-  # UDP proxy port for power meter emulation (see https://github.com/tomquist/b2500-meter)
+  # UDP proxy port for Shelly power meter discovery (see https://github.com/tomquist/b2500-meter)
+  # Only needed for Shelly device emulation (not CT001/CT002 which use TCP):
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   udp_proxy_port: "1010"

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -9,6 +9,7 @@ substitutions:
   mqtt_username: "mqtt_user"
   mqtt_password: "mqtt_password"
   mqtt_topic_prefix: "marsrelay"
+  udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.
     enabled: true
@@ -55,9 +56,7 @@ capture_dns:
   id: capture_dns_server
 
 udp_proxy:
-  - id: udp_bridge
-    port: 48899
-    session_timeout: 30s
+  - port: ${udp_proxy_port}
 
 mqtt:
   id: mqtt_client

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -9,10 +9,12 @@ substitutions:
   mqtt_username: "mqtt_user"
   mqtt_password: "mqtt_password"
   mqtt_topic_prefix: "marsrelay"
-  # UDP proxy port for Shelly power meter discovery (see https://github.com/tomquist/b2500-meter)
-  # Only needed for Shelly device emulation (not CT001/CT002 which use TCP):
+  # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
+  # - Port 2222: Shelly 3EM gen3
+  # - Port 2223: Shelly Pro EM50
+  # - Port 12345: CT001/CT002/CT003
   udp_proxy_port: "1010"
   psram:
     # Set to true if your ESP32S3 has PSRAM.

--- a/tests/component_tests/marsrelay/test_marsrelay.py
+++ b/tests/component_tests/marsrelay/test_marsrelay.py
@@ -9,3 +9,4 @@ def test_marsrelay_component_generation(generate_main):
     assert "mosquitto_broker::MosquittoBroker" in main_cpp
     assert "marstack::Marstack" in main_cpp
     assert "capture_dns::CaptiveDns" in main_cpp
+    assert "udp_proxy::UdpProxy" in main_cpp


### PR DESCRIPTION
This component enables UDP packet forwarding between the Marstek device
(connected to the AP network) and the home network (STA connection).
Key features:
- Listens for UDP broadcasts from AP clients on a configurable port
- Forwards broadcasts to the STA network
- Tracks client sessions to route responses back to original senders
- Configurable session timeout for cleanup
- Session management handles multiple concurrent clients

This is essential for zero feed-in control where the storage device
needs to communicate with devices (like smart meters) on the home network.