### PR TITLE
Add CI job to build with remote components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,18 @@ jobs:
         uses: esphome/build-action@v6
         with:
           yaml-file: marsrelay_esp32s3.yaml
+
+  build-remote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Replace local components with remote source
+        run: |
+          yq -i '.external_components[0].source = "github://${{ github.repository }}@${{ github.sha }}"' marsrelay_esp32s3.yaml
+      - name: Show modified external_components config
+        run: yq '.external_components' marsrelay_esp32s3.yaml
+      - name: Build firmware with remote components
+        uses: esphome/build-action@v6
+        with:
+          yaml-file: marsrelay_esp32s3.yaml


### PR DESCRIPTION
Add a concurrent build-remote job that validates external components
work correctly when sourced from GitHub. Uses yq to replace the local
component source with a remote GitHub source pointing to the repo and
commit SHA being built.