### PR TITLE
Shelly UDP emulator based on ESPHome sensors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,16 @@ jobs:
         with:
           yaml-file: marsrelay_esp32s3.yaml
 
+  build-shelly-emulator-example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Shelly emulator example config (E2E)
+        uses: esphome/build-action@v6
+        with:
+          yaml-file: tests/fixtures/shelly_emulator.yaml
+
   build-remote:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -219,6 +219,34 @@ Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://githu
 
 ---
 
+## Optional: Shelly UDP Emulator (Issue #6)
+
+Marsrelay can emulate a Shelly Gen2 energy meter (UDP JSON-RPC) using ESPHome sensor values.
+This is based on the Shelly emulation implemented in <https://github.com/tomquist/b2500-meter>.
+
+Example:
+
+```yaml
+sensor:
+  - platform: template
+    id: grid_power_w
+    name: Grid Power
+    unit_of_measurement: W
+
+shelly_emulator:
+  # Use the port expected by your Marstek/B2500 firmware
+  # (e.g. 1010 / 2220 / 2222 / 2223)
+  port: 1010
+  device_id: marsrelay
+  # One sensor (total) or three sensors (a/b/c phases)
+  power_sensors:
+    - grid_power_w
+```
+
+Supported methods:
+- `EM.GetStatus` (returns `a_act_power`, `b_act_power`, `c_act_power`, `total_act_power`)
+- `EM1.GetStatus` (returns `act_power`)
+
 ## Technical Details
 
 This repository contains ESPHome external components for building Marsrelay:
@@ -229,6 +257,7 @@ This repository contains ESPHome external components for building Marsrelay:
 - **`marstack`**: A web server component that implements Marstek's API endpoints
 - **`capture_dns`**: DNS redirection component that intercepts DNS queries and redirects them to the device
 - **`udp_proxy`**: UDP proxy component that bridges UDP broadcasts between the AP network (where Marstek devices connect) and the STA network (your home network). This enables zero feed-in control by forwarding UDP discovery/control packets between networks. Supports multiple ports.
+- **`shelly_emulator`**: Shelly UDP (Gen2) emulator for `EM.GetStatus`/`EM1.GetStatus` based on ESPHome sensor(s). Can be used to provide Shelly-compatible power readings directly from the ESP.
 - **`wifi`**: Patched WiFi component to support simultaneous access point while station mode is enabled
 
 ### Requirements

--- a/components/shelly_emulator/__init__.py
+++ b/components/shelly_emulator/__init__.py
@@ -1,0 +1,70 @@
+import esphome.codegen as cg
+from esphome.config_helpers import filter_source_files_from_platform
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_PORT,
+    PLATFORM_ESP32,
+    PlatformFramework,
+)
+from esphome.core import CORE, coroutine_with_priority
+from esphome.coroutine import CoroPriority
+from esphome.types import ConfigType
+from esphome.components import sensor
+
+
+def AUTO_LOAD() -> list[str]:
+    auto_load = []
+    if CORE.is_esp32:
+        auto_load.append("socket")
+    return auto_load
+
+
+DEPENDENCIES = ["wifi"]
+CODEOWNERS = ["@marsrelay"]
+MULTI_CONF = True
+
+CONF_DEVICE_ID = "device_id"
+CONF_POWER_SENSORS = "power_sensors"
+
+shelly_emulator_ns = cg.esphome_ns.namespace("shelly_emulator")
+ShellyEmulator = shelly_emulator_ns.class_("ShellyEmulator", cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ShellyEmulator),
+            cv.Optional(CONF_DEVICE_ID, default="marsrelay"): cv.string,
+            cv.Required(CONF_PORT): cv.port,
+            cv.Required(CONF_POWER_SENSORS): cv.All(
+                cv.ensure_list(cv.use_id(sensor.Sensor)),
+                cv.Length(min=1, max=3),
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    cv.only_on([PLATFORM_ESP32]),
+)
+
+
+@coroutine_with_priority(CoroPriority.CAPTIVE_PORTAL)
+async def to_code(config: ConfigType):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add_define("USE_SHELLY_EMULATOR")
+
+    cg.add(var.set_port(config[CONF_PORT]))
+    cg.add(var.set_device_id(config[CONF_DEVICE_ID]))
+
+    for sens in config[CONF_POWER_SENSORS]:
+        s = await cg.get_variable(sens)
+        cg.add(var.add_power_sensor(s))
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "shelly_emulator.cpp": {
+            PlatformFramework.ESP32_IDF,
+        },
+    }
+)

--- a/components/shelly_emulator/__init__.py
+++ b/components/shelly_emulator/__init__.py
@@ -14,13 +14,15 @@ from esphome.components import sensor
 
 
 def AUTO_LOAD() -> list[str]:
-    auto_load = []
+    # Ensure required core components are loaded so their build flags/libs are available.
+    # In particular, the ESPHome `json` component pulls in ArduinoJson for both Arduino and ESP-IDF.
+    auto_load: list[str] = []
     if CORE.is_esp32:
-        auto_load.append("socket")
+        auto_load.extend(["socket", "json"])
     return auto_load
 
 
-DEPENDENCIES = ["wifi"]
+DEPENDENCIES = ["wifi", "json"]
 CODEOWNERS = ["@marsrelay"]
 MULTI_CONF = True
 

--- a/components/shelly_emulator/shelly_emulator.cpp
+++ b/components/shelly_emulator/shelly_emulator.cpp
@@ -1,0 +1,219 @@
+#include "shelly_emulator.h"
+
+#ifdef USE_SHELLY_EMULATOR
+
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+
+#include <ArduinoJson.h>
+#include <lwip/sockets.h>
+#include <cstring>
+
+namespace esphome {
+namespace shelly_emulator {
+
+static const char *const TAG = "shelly_emulator";
+
+void ShellyEmulator::setup() { this->start_(); }
+
+float ShellyEmulator::get_setup_priority() const {
+  // After WiFi
+  return setup_priority::WIFI - 1.0f;
+}
+
+void ShellyEmulator::dump_config() {
+  ESP_LOGCONFIG(TAG, "Shelly UDP Emulator:");
+  ESP_LOGCONFIG(TAG, "  Port: %u", this->port_);
+  ESP_LOGCONFIG(TAG, "  Device ID: %s", this->device_id_.c_str());
+  ESP_LOGCONFIG(TAG, "  Power sensors: %u", (unsigned) this->power_sensors_.size());
+  ESP_LOGCONFIG(TAG, "  Active: %s", this->active_ ? "Yes" : "No");
+}
+
+void ShellyEmulator::start_() {
+  if (this->active_) {
+    ESP_LOGW(TAG, "Shelly emulator already active");
+    return;
+  }
+
+  if (this->port_ == 0) {
+    ESP_LOGE(TAG, "No port configured for Shelly emulator");
+    return;
+  }
+
+  this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+  if (this->socket_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create UDP socket");
+    return;
+  }
+
+  int enable = 1;
+  this->socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+
+  // Bind to all interfaces on the target port
+  struct sockaddr_storage addr = {};
+  socklen_t addr_len = socket::set_sockaddr_any((struct sockaddr *) &addr, sizeof(addr), this->port_);
+
+  int err = this->socket_->bind((struct sockaddr *) &addr, addr_len);
+  if (err != 0) {
+    ESP_LOGE(TAG, "Failed to bind UDP socket to port %u: %d (%s)", this->port_, errno, strerror(errno));
+    this->socket_ = nullptr;
+    return;
+  }
+
+  this->active_ = true;
+  ESP_LOGI(TAG, "Shelly UDP emulator listening on port %u", this->port_);
+}
+
+void ShellyEmulator::loop() {
+  if (!this->active_) {
+    return;
+  }
+
+  this->process_socket_();
+}
+
+float ShellyEmulator::calculate_derived_value_(float power) const {
+  const float decimal_point_enforcer = 0.001f;
+  if (std::isnan(power))
+    power = 0.0f;
+
+  if (std::abs(power) < 0.1f) {
+    return decimal_point_enforcer;
+  }
+
+  float rounded = std::round(power);
+  float ret = std::round(power * 10.0f) / 10.0f;
+  if (power == rounded || power == 0.0f) {
+    ret += decimal_point_enforcer;
+  }
+  return ret;
+}
+
+void ShellyEmulator::fill_powers_(std::vector<float> &powers) const {
+  powers.clear();
+  powers.reserve(this->power_sensors_.size());
+
+  for (auto *s : this->power_sensors_) {
+    float v = 0.0f;
+    if (s != nullptr) {
+      v = s->state;
+      if (std::isnan(v))
+        v = 0.0f;
+    }
+    powers.push_back(v);
+  }
+
+  if (powers.size() == 1) {
+    powers = {powers[0], 0.0f, 0.0f};
+  } else if (powers.size() != 3) {
+    powers = {0.0f, 0.0f, 0.0f};
+  }
+}
+
+void ShellyEmulator::process_socket_() {
+  if (this->socket_ == nullptr || !this->socket_->ready()) {
+    return;
+  }
+
+  int fd = this->socket_->get_fd();
+  if (fd < 0) {
+    return;
+  }
+
+  struct sockaddr_in client_addr;
+  socklen_t client_addr_len = sizeof(client_addr);
+
+  ssize_t len = recvfrom(fd, this->buffer_, sizeof(this->buffer_) - 1, MSG_DONTWAIT,
+                         (struct sockaddr *) &client_addr, &client_addr_len);
+
+  if (len < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+      ESP_LOGW(TAG, "recvfrom failed: %d (%s)", errno, strerror(errno));
+    }
+    return;
+  }
+
+  if (len == 0) {
+    return;
+  }
+
+  this->buffer_[len] = 0;
+
+  // Parse request
+  DynamicJsonDocument req_doc(768);
+  DeserializationError err = deserializeJson(req_doc, (const char *) this->buffer_, len);
+  if (err) {
+    ESP_LOGV(TAG, "Invalid JSON: %s", err.c_str());
+    return;
+  }
+
+  JsonVariant id_v = req_doc["id"];
+  if (!id_v.is<int>()) {
+    return;
+  }
+  int request_id = id_v.as<int>();
+
+  const char *method = req_doc["method"] | "";
+  JsonVariant params_id = req_doc["params"]["id"];
+  if (!params_id.is<int>()) {
+    // Shelly clients usually send params.id
+    return;
+  }
+
+  // Gather sensor values
+  std::vector<float> powers;
+  this->fill_powers_(powers);
+
+  // Build response
+  DynamicJsonDocument resp_doc(768);
+  resp_doc["id"] = request_id;
+  resp_doc["src"] = this->device_id_;
+  resp_doc["dst"] = "unknown";
+
+  JsonObject result = resp_doc.createNestedObject("result");
+
+  if (std::strcmp(method, "EM.GetStatus") == 0) {
+    float a = this->calculate_derived_value_(powers[0]);
+    float b = this->calculate_derived_value_(powers[1]);
+    float c = this->calculate_derived_value_(powers[2]);
+
+    float total = powers[0] + powers[1] + powers[2];
+    float total_rounded = std::round(total * 1000.0f) / 1000.0f;
+    if (total == std::round(total) || total == 0.0f) {
+      total_rounded += 0.001f;
+    }
+
+    result["a_act_power"] = a;
+    result["b_act_power"] = b;
+    result["c_act_power"] = c;
+    result["total_act_power"] = total_rounded;
+  } else if (std::strcmp(method, "EM1.GetStatus") == 0) {
+    float total = powers[0] + powers[1] + powers[2];
+    float total_rounded = std::round(total * 1000.0f) / 1000.0f;
+    if (total == std::round(total) || total == 0.0f) {
+      total_rounded += 0.001f;
+    }
+
+    result["act_power"] = total_rounded;
+  } else {
+    // Unsupported method
+    return;
+  }
+
+  char out[512];
+  size_t out_len = serializeJson(resp_doc, out, sizeof(out));
+  if (out_len == 0) {
+    ESP_LOGW(TAG, "Failed to serialize response");
+    return;
+  }
+
+  ssize_t sent = this->socket_->sendto(out, out_len, 0, (struct sockaddr *) &client_addr, client_addr_len);
+  if (sent < 0) {
+    ESP_LOGW(TAG, "sendto failed: %d (%s)", errno, strerror(errno));
+  }
+}
+
+}  // namespace shelly_emulator
+}  // namespace esphome
+
+#endif  // USE_SHELLY_EMULATOR

--- a/components/shelly_emulator/shelly_emulator.h
+++ b/components/shelly_emulator/shelly_emulator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+
+#ifdef USE_SHELLY_EMULATOR
+
+#include "esphome/components/socket/socket.h"
+
+namespace esphome {
+namespace shelly_emulator {
+
+class ShellyEmulator : public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  float get_setup_priority() const override;
+  void dump_config() override;
+
+  void set_port(uint16_t port) { this->port_ = port; }
+  void set_device_id(const std::string &device_id) { this->device_id_ = device_id; }
+  void add_power_sensor(sensor::Sensor *sensor) { this->power_sensors_.push_back(sensor); }
+
+ protected:
+  void start_();
+  void process_socket_();
+
+  float calculate_derived_value_(float power) const;
+  void fill_powers_(std::vector<float> &powers) const;
+
+  std::string device_id_{"marsrelay"};
+  uint16_t port_{0};
+
+  std::vector<sensor::Sensor *> power_sensors_;
+
+  std::unique_ptr<socket::Socket> socket_;
+  bool active_{false};
+
+  uint8_t buffer_[1024]{};
+};
+
+}  // namespace shelly_emulator
+}  // namespace esphome
+
+#endif  // USE_SHELLY_EMULATOR

--- a/tests/component_tests/shelly_emulator/test_shelly_emulator.py
+++ b/tests/component_tests/shelly_emulator/test_shelly_emulator.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_shelly_emulator_component_generation(generate_main):
+    root_config = Path(__file__).parents[3] / "tests" / "fixtures" / "shelly_emulator.yaml"
+    main_cpp = generate_main(str(root_config))
+    assert "shelly_emulator::ShellyEmulator" in main_cpp

--- a/tests/fixtures/shelly_emulator.yaml
+++ b/tests/fixtures/shelly_emulator.yaml
@@ -16,7 +16,7 @@ wifi:
   password: "testpass"
   ap:
     ssid: "fallback"
-    password: "fallback"
+    password: "fallbackpass"
 
 logger:
 

--- a/tests/fixtures/shelly_emulator.yaml
+++ b/tests/fixtures/shelly_emulator.yaml
@@ -13,7 +13,7 @@ external_components:
 
 wifi:
   ssid: "test"
-  password: "test"
+  password: "testpass"
   ap:
     ssid: "fallback"
     password: "fallback"

--- a/tests/fixtures/shelly_emulator.yaml
+++ b/tests/fixtures/shelly_emulator.yaml
@@ -4,7 +4,7 @@ esphome:
 esp32:
   board: esp32dev
   framework:
-    type: esp-idf
+    type: arduino
 
 external_components:
   - source:

--- a/tests/fixtures/shelly_emulator.yaml
+++ b/tests/fixtures/shelly_emulator.yaml
@@ -1,0 +1,34 @@
+esphome:
+  name: test-shelly-emulator
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+external_components:
+  - source:
+      type: local
+      path: ../../components
+
+wifi:
+  ssid: "test"
+  password: "test"
+  ap:
+    ssid: "fallback"
+    password: "fallback"
+
+logger:
+
+sensor:
+  - platform: template
+    id: power_w
+    name: "Power"
+    unit_of_measurement: W
+    accuracy_decimals: 1
+
+shelly_emulator:
+  port: 1010
+  device_id: "test"
+  power_sensors:
+    - power_w

--- a/tests/fixtures/shelly_emulator.yaml
+++ b/tests/fixtures/shelly_emulator.yaml
@@ -4,7 +4,7 @@ esphome:
 esp32:
   board: esp32dev
   framework:
-    type: arduino
+    type: esp-idf
 
 external_components:
   - source:


### PR DESCRIPTION
Implements a Shelly (Gen2) UDP JSON-RPC emulator directly on the ESP, based on ESPHome sensor values.

- Adds new external component `shelly_emulator`.
- Supports `EM.GetStatus` and `EM1.GetStatus`.
- `power_sensors` is configurable (1 sensor = total/phase A; 3 sensors = phases A/B/C). Any other count falls back to 0.
- Adds minimal docs + codegen test.

Assumptions / notes:
- Only ESP32 (ESP-IDF) is supported for now (uses LWIP sockets), matching the rest of the repo.
- The emulator mirrors the decimal-point enforcement behavior from https://github.com/tomquist/b2500-meter to avoid integer-looking values.

Closes #6
