### PR TITLE
chore: update custom wifi component to ESPHome 2026.3.0

### DIFF
--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -25,7 +25,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: python -m pip install esphome==${{ inputs.esphome_version }} pytest
+        run: |
+          if [ "${{ inputs.esphome_version }}" = "latest" ]; then
+            python -m pip install esphome pytest
+          else
+            python -m pip install esphome==${{ inputs.esphome_version }} pytest
+          fi
       - name: Run component tests
         run: pytest -q
 

--- a/.github/workflows/ci-dispatch.yml
+++ b/.github/workflows/ci-dispatch.yml
@@ -1,0 +1,68 @@
+name: CI Dispatch
+
+on:
+  workflow_call:
+    inputs:
+      esphome_version:
+        description: ESPHome version for build/test jobs (e.g. 2026.3.0 or latest)
+        required: true
+        type: string
+      run_tests:
+        description: Run pytest component tests
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  test:
+    if: ${{ inputs.run_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install esphome==${{ inputs.esphome_version }} pytest
+      - name: Run component tests
+        run: pytest -q
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build firmware
+        uses: esphome/build-action@v6
+        with:
+          version: ${{ inputs.esphome_version }}
+          yaml-file: marsrelay_esp32s3.yaml
+
+  build-remote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Replace local components with remote source
+        run: |
+          yq -i '.external_components[0].source = "github://${{ github.repository }}@${{ github.sha }}"' marsrelay_esp32s3.yaml
+      - name: Show modified external_components config
+        run: yq '.external_components' marsrelay_esp32s3.yaml
+      - name: Build firmware with remote components
+        uses: esphome/build-action@v6
+        with:
+          version: ${{ inputs.esphome_version }}
+          yaml-file: marsrelay_esp32s3.yaml
+
+  build-shelly-emulator-example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Shelly emulator example config (E2E)
+        uses: esphome/build-action@v6
+        with:
+          version: ${{ inputs.esphome_version }}
+          yaml-file: tests/fixtures/shelly_emulator.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,89 +3,10 @@ name: CI
 on:
   push:
   pull_request:
-  schedule:
-    - cron: "0 3 * * *"
 
 jobs:
-  test:
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: python -m pip install esphome==2026.3.0 pytest
-      - name: Run component tests
-        run: pytest -q
-
-  build:
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build firmware
-        uses: esphome/build-action@v6
-        with:
-          version: 2026.3.0
-          yaml-file: marsrelay_esp32s3.yaml
-
-  build-shelly-emulator-example:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Shelly emulator example config (E2E)
-        uses: esphome/build-action@v6
-        with:
-          yaml-file: tests/fixtures/shelly_emulator.yaml
-
-  build-remote:
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Replace local components with remote source
-        run: |
-          yq -i '.external_components[0].source = "github://${{ github.repository }}@${{ github.sha }}"' marsrelay_esp32s3.yaml
-      - name: Show modified external_components config
-        run: yq '.external_components' marsrelay_esp32s3.yaml
-      - name: Build firmware with remote components
-        uses: esphome/build-action@v6
-        with:
-          version: 2026.3.0
-          yaml-file: marsrelay_esp32s3.yaml
-
-  nightly-build-latest:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build firmware (latest ESPHome)
-        uses: esphome/build-action@v6
-        with:
-          version: latest
-          yaml-file: marsrelay_esp32s3.yaml
-
-  nightly-build-remote-latest:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Replace local components with remote source
-        run: |
-          yq -i '.external_components[0].source = "github://${{ github.repository }}@${{ github.sha }}"' marsrelay_esp32s3.yaml
-      - name: Show modified external_components config
-        run: yq '.external_components' marsrelay_esp32s3.yaml
-      - name: Build firmware with remote components (latest ESPHome)
-        uses: esphome/build-action@v6
-        with:
-          version: latest
-          yaml-file: marsrelay_esp32s3.yaml
+  ci:
+    uses: ./.github/workflows/ci-dispatch.yml
+    with:
+      esphome_version: "2026.3.0"
+      run_tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,12 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron: "0 3 * * *"
 
 jobs:
   test:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,11 +18,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: python -m pip install esphome pytest
+        run: python -m pip install esphome==2026.3.0 pytest
       - name: Run component tests
         run: pytest -q
 
   build:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,6 +31,7 @@ jobs:
       - name: Build firmware
         uses: esphome/build-action@v6
         with:
+          version: 2026.3.0
           yaml-file: marsrelay_esp32s3.yaml
 
   build-shelly-emulator-example:
@@ -40,6 +45,7 @@ jobs:
           yaml-file: tests/fixtures/shelly_emulator.yaml
 
   build-remote:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,4 +58,34 @@ jobs:
       - name: Build firmware with remote components
         uses: esphome/build-action@v6
         with:
+          version: 2026.3.0
+          yaml-file: marsrelay_esp32s3.yaml
+
+  nightly-build-latest:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build firmware (latest ESPHome)
+        uses: esphome/build-action@v6
+        with:
+          version: latest
+          yaml-file: marsrelay_esp32s3.yaml
+
+  nightly-build-remote-latest:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Replace local components with remote source
+        run: |
+          yq -i '.external_components[0].source = "github://${{ github.repository }}@${{ github.sha }}"' marsrelay_esp32s3.yaml
+      - name: Show modified external_components config
+        run: yq '.external_components' marsrelay_esp32s3.yaml
+      - name: Build firmware with remote components (latest ESPHome)
+        uses: esphome/build-action@v6
+        with:
+          version: latest
           yaml-file: marsrelay_esp32s3.yaml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,12 @@
+name: Nightly CI
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+jobs:
+  nightly:
+    uses: ./.github/workflows/ci-dispatch.yml
+    with:
+      esphome_version: "latest"
+      run_tests: true

--- a/components/capture_dns/__init__.py
+++ b/components/capture_dns/__init__.py
@@ -69,7 +69,7 @@ def _final_validate(config: ConfigType) -> ConfigType:
     if CORE.is_esp32:
         from esphome.components import socket
 
-        socket.consume_sockets(1, "capture_dns")(config)
+        socket.consume_sockets(1, "capture_dns", socket.SocketType.UDP)(config)
 
     return config
 

--- a/components/capture_dns/dns_server_esp32_idf.cpp
+++ b/components/capture_dns/dns_server_esp32_idf.cpp
@@ -4,22 +4,23 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include "esphome/components/socket/socket.h"
-#include "esphome/components/network/ip_address.h"
 #include <lwip/sockets.h>
 #include <lwip/inet.h>
-#include <cstring>
 
 namespace esphome::capture_dns {
 
 static const char *const TAG = "capture_dns.dns";
 
+// DNS constants
 static constexpr uint16_t DNS_PORT = 53;
 static constexpr uint16_t DNS_QR_FLAG = 1 << 15;
+static constexpr uint16_t DNS_AA_FLAG = 1 << 10;
 static constexpr uint16_t DNS_OPCODE_MASK = 0x7800;
 static constexpr uint16_t DNS_QTYPE_A = 0x0001;
 static constexpr uint16_t DNS_QCLASS_IN = 0x0001;
 static constexpr uint16_t DNS_ANSWER_TTL = 300;
 
+// DNS Header structure
 struct DNSHeader {
   uint16_t id;
   uint16_t flags;
@@ -29,11 +30,13 @@ struct DNSHeader {
   uint16_t ar_count;
 } __attribute__((packed));
 
+// DNS Question structure
 struct DNSQuestion {
   uint16_t type;
   uint16_t dns_class;
 } __attribute__((packed));
 
+// DNS Answer structure
 struct DNSAnswer {
   uint16_t ptr_offset;
   uint16_t type;
@@ -45,47 +48,49 @@ struct DNSAnswer {
 
 void DNSServer::start(const network::IPAddress &ip) {
   this->server_ip_ = ip;
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
-  ESP_LOGI(TAG, "Starting DNS server, will respond with IP: %s", ip.str_to(ip_buf));
+  ESP_LOGV(TAG, "Starting DNS server on %s", ip.str_to(ip_buf));
+#endif
 
-  this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+  // Create loop-monitored UDP socket
+  this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP).release();
   if (this->socket_ == nullptr) {
-    ESP_LOGE(TAG, "Failed to create UDP socket for DNS server");
+    ESP_LOGE(TAG, "Socket create failed");
     return;
   }
 
+  // Set socket options
   int enable = 1;
   this->socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
 
+  // Bind to port 53
   struct sockaddr_storage server_addr = {};
   socklen_t addr_len = socket::set_sockaddr_any((struct sockaddr *) &server_addr, sizeof(server_addr), DNS_PORT);
 
   int err = this->socket_->bind((struct sockaddr *) &server_addr, addr_len);
   if (err != 0) {
-    ESP_LOGE(TAG, "Failed to bind DNS server to port %d: %d (%s)", DNS_PORT, errno, strerror(errno));
-    this->socket_ = nullptr;
+    ESP_LOGE(TAG, "Bind failed: %d", errno);
+    this->destroy_socket_();
     return;
   }
-  ESP_LOGI(TAG, "DNS server bound to port %d", DNS_PORT);
+  ESP_LOGV(TAG, "Bound to port %d", DNS_PORT);
 }
 
 void DNSServer::stop() {
-  if (this->socket_ != nullptr) {
-    this->socket_->close();
-    this->socket_ = nullptr;
-    ESP_LOGI(TAG, "DNS server stopped and socket closed");
-  } else {
-    ESP_LOGV(TAG, "DNS server already stopped");
-  }
+  this->destroy_socket_();
+  ESP_LOGV(TAG, "Stopped");
 }
 
 void DNSServer::process_next_request() {
+  // Process one request if socket is valid and data is available
   if (this->socket_ == nullptr || !this->socket_->ready()) {
     return;
   }
   struct sockaddr_in client_addr;
   socklen_t client_addr_len = sizeof(client_addr);
 
+  // Receive DNS request using raw fd for recvfrom
   int fd = this->socket_->get_fd();
   if (fd < 0) {
     return;
@@ -96,118 +101,103 @@ void DNSServer::process_next_request() {
 
   if (len < 0) {
     if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
-      ESP_LOGE(TAG, "recvfrom failed: %d (%s)", errno, strerror(errno));
+      ESP_LOGE(TAG, "recvfrom failed: %d", errno);
     }
     return;
   }
 
-  const char *client_ip = inet_ntoa(client_addr.sin_addr);
-  uint16_t client_port = ntohs(client_addr.sin_port);
-  ESP_LOGD(TAG, "Received DNS query: %d bytes from %s:%d", len, client_ip, client_port);
+  ESP_LOGVV(TAG, "Received %d bytes from %s:%d", len, inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port));
 
   if (len < static_cast<ssize_t>(sizeof(DNSHeader) + 1)) {
-    ESP_LOGW(TAG, "DNS request too short (%d bytes), minimum %zu bytes required", len, sizeof(DNSHeader) + 1);
+    ESP_LOGV(TAG, "Request too short: %d", len);
     return;
   }
 
+  // Parse DNS header
   DNSHeader *header = (DNSHeader *) this->buffer_;
   uint16_t flags = ntohs(header->flags);
   uint16_t qd_count = ntohs(header->qd_count);
-  uint16_t query_id = ntohs(header->id);
 
+  // Check if it's a standard query
   if ((flags & DNS_QR_FLAG) || (flags & DNS_OPCODE_MASK) || qd_count != 1) {
-    ESP_LOGW(TAG, "Invalid DNS query: id=0x%04X, flags=0x%04X, qd_count=%d (expected 1)", query_id, flags, qd_count);
-    return;
+    ESP_LOGV(TAG, "Not a standard query: flags=0x%04X, qd_count=%d", flags, qd_count);
+    return;  // Not a standard query
   }
 
+  // Parse domain name (we don't actually care about it - redirect everything)
   uint8_t *ptr = this->buffer_ + sizeof(DNSHeader);
   uint8_t *end = this->buffer_ + len;
-  uint8_t *domain_start = ptr;
-  char domain_name[256] = {0};
-  size_t domain_pos = 0;
 
-  // Parse domain name and build string representation
   while (ptr < end && *ptr != 0) {
     uint8_t label_len = *ptr;
-    if (label_len > 63) {
-      ESP_LOGW(TAG, "Invalid label length %d in domain name", label_len);
+    if (label_len > 63) {  // Check for invalid label length
       return;
     }
+    // Check if we have room for this label plus the length byte
     if (ptr + label_len + 1 > end) {
-      ESP_LOGW(TAG, "Domain name extends beyond packet boundary");
-      return;
-    }
-    if (domain_pos > 0 && domain_pos < sizeof(domain_name) - 1) {
-      domain_name[domain_pos++] = '.';
-    }
-    for (uint8_t i = 0; i < label_len && domain_pos < sizeof(domain_name) - 1; i++) {
-      domain_name[domain_pos++] = ptr[i + 1];
+      return;  // Would overflow
     }
     ptr += label_len + 1;
   }
 
+  // Check if we reached a proper null terminator
   if (ptr >= end || *ptr != 0) {
-    ESP_LOGW(TAG, "Domain name not properly terminated");
-    return;
+    return;  // Name not terminated or truncated
   }
-  ptr++;
-  
-  if (domain_pos > 0) {
-    ESP_LOGD(TAG, "DNS query [id=0x%04X] for domain: %s", query_id, domain_name);
-  } else {
-    ESP_LOGD(TAG, "DNS query [id=0x%04X] for root domain", query_id);
-  }
+  ptr++;  // Skip the null terminator
 
+  // Check we have room for the question
   if (ptr + sizeof(DNSQuestion) > end) {
-    ESP_LOGW(TAG, "DNS question extends beyond packet boundary");
-    return;
+    return;  // Request truncated
   }
 
+  // Parse DNS question
   DNSQuestion *question = (DNSQuestion *) ptr;
   uint16_t qtype = ntohs(question->type);
   uint16_t qclass = ntohs(question->dns_class);
 
+  // We only handle A queries
   if (qtype != DNS_QTYPE_A || qclass != DNS_QCLASS_IN) {
-    ESP_LOGD(TAG, "DNS query type not A/IN: type=0x%04X, class=0x%04X (expected A=0x%04X, IN=0x%04X)", 
-             qtype, qclass, DNS_QTYPE_A, DNS_QCLASS_IN);
-    return;
+    ESP_LOGV(TAG, "Not an A query: type=0x%04X, class=0x%04X", qtype, qclass);
+    return;  // Not an A query
   }
 
-  header->flags = htons(DNS_QR_FLAG | 0x8000);
-  header->an_count = htons(1);
+  // Build DNS response by modifying the request in-place
+  header->flags = htons(DNS_QR_FLAG | DNS_AA_FLAG);  // Response + Authoritative
+  header->an_count = htons(1);                       // One answer
 
+  // Add answer section after the question
   size_t question_len = (ptr + sizeof(DNSQuestion)) - this->buffer_ - sizeof(DNSHeader);
   size_t answer_offset = sizeof(DNSHeader) + question_len;
 
+  // Check if we have room for the answer
   if (answer_offset + sizeof(DNSAnswer) > sizeof(this->buffer_)) {
-    ESP_LOGE(TAG, "DNS response too large: %zu bytes (max %zu)", answer_offset + sizeof(DNSAnswer), sizeof(this->buffer_));
+    ESP_LOGW(TAG, "Response too large");
     return;
   }
 
   DNSAnswer *answer = (DNSAnswer *) (this->buffer_ + answer_offset);
 
+  // Pointer to name in question (offset from start of packet)
   answer->ptr_offset = htons(0xC000 | sizeof(DNSHeader));
   answer->type = htons(DNS_QTYPE_A);
   answer->dns_class = htons(DNS_QCLASS_IN);
   answer->ttl = htonl(DNS_ANSWER_TTL);
   answer->addr_len = htons(4);
 
+  // Get the raw IP address
   ip4_addr_t addr = this->server_ip_;
   answer->ip_addr = addr.addr;
 
   size_t response_len = answer_offset + sizeof(DNSAnswer);
 
-  char response_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
-  const char *response_ip_str = this->server_ip_.str_to(response_ip_buf);
-  
+  // Send response
   ssize_t sent =
       this->socket_->sendto(this->buffer_, response_len, 0, (struct sockaddr *) &client_addr, client_addr_len);
   if (sent < 0) {
-    ESP_LOGE(TAG, "Failed to send DNS response to %s:%d: %d (%s)", 
-             inet_ntoa(client_addr.sin_addr), ntohs(client_addr.sin_port), errno, strerror(errno));
+    ESP_LOGV(TAG, "Send failed: %d", errno);
   } else {
-    ESP_LOGD(TAG, "Sent DNS response [id=0x%04X]: %zd bytes, answered %s with %s (TTL=%d)", 
-             query_id, sent, domain_pos > 0 ? domain_name : "<root>", response_ip_str, DNS_ANSWER_TTL);
+    ESP_LOGV(TAG, "Sent %d bytes", sent);
   }
 }
 

--- a/components/capture_dns/dns_server_esp32_idf.h
+++ b/components/capture_dns/dns_server_esp32_idf.h
@@ -1,7 +1,6 @@
 #pragma once
 #ifdef USE_ESP32
 
-#include <memory>
 #include "esphome/core/helpers.h"
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/socket/socket.h"
@@ -15,9 +14,15 @@ class DNSServer {
   void process_next_request();
 
  protected:
+  // No explicit close() needed — listen sockets have no active connections on
+  // failure/shutdown. Destructor handles fd cleanup (close or abort per platform).
+  inline void destroy_socket_() {
+    delete this->socket_;
+    this->socket_ = nullptr;
+  }
   static constexpr size_t DNS_BUFFER_SIZE = 192;
 
-  std::unique_ptr<socket::Socket> socket_{nullptr};
+  socket::ListenSocket *socket_{nullptr};
   network::IPAddress server_ip_;
   uint8_t buffer_[DNS_BUFFER_SIZE];
 };

--- a/components/mosquitto_broker/__init__.py
+++ b/components/mosquitto_broker/__init__.py
@@ -74,6 +74,7 @@ async def to_code(config):
             cv.Required("payload"): cv.templatable(cv.string_strict),
         }
     ),
+    synchronous=True,
 )
 async def publish_message_action_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/components/shelly_emulator/shelly_emulator.h
+++ b/components/shelly_emulator/shelly_emulator.h
@@ -33,7 +33,7 @@ class ShellyEmulator : public Component {
 
   std::vector<sensor::Sensor *> power_sensors_;
 
-  std::unique_ptr<socket::Socket> socket_;
+  std::unique_ptr<socket::ListenSocket> socket_;
   bool active_{false};
 
   uint8_t buffer_[1024]{};

--- a/components/udp_proxy/udp_proxy.h
+++ b/components/udp_proxy/udp_proxy.h
@@ -68,10 +68,10 @@ class UdpProxy : public Component {
   bool active_{false};
 
   /// Socket listening on the AP network (receives from Marstek device)
-  std::unique_ptr<socket::Socket> ap_socket_{nullptr};
+  std::unique_ptr<socket::ListenSocket> ap_socket_{nullptr};
 
   /// Socket for STA network communication (forwards to home network, receives responses)
-  std::unique_ptr<socket::Socket> sta_socket_{nullptr};
+  std::unique_ptr<socket::ListenSocket> sta_socket_{nullptr};
 
   /// Map of STA-side source port to session info for routing responses back
   /// Key is a session identifier (we use a simple incrementing counter)

--- a/components/wifi/__init__.py
+++ b/components/wifi/__init__.py
@@ -1,10 +1,16 @@
 import logging
+import math
 
 from esphome import automation
 from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components.const import CONF_USE_PSRAM
-from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
+from esphome.components.esp32 import (
+    add_idf_sdkconfig_option,
+    const,
+    get_esp32_variant,
+    only_on_variant,
+)
 from esphome.components.network import (
     has_high_performance_networking,
     ip_address_literal,
@@ -36,6 +42,7 @@ from esphome.const import (
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
     CONF_ON_ERROR,
+    CONF_OUTPUT_POWER,
     CONF_PASSWORD,
     CONF_POWER_SAVE_MODE,
     CONF_PRIORITY,
@@ -52,6 +59,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, CoroPriority, HexInt, coroutine_with_priority
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 from . import wpa2_eap
 
@@ -63,6 +71,7 @@ _LOGGER = logging.getLogger(__name__)
 
 NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2, const.VARIANT_ESP32P4]
 CONF_SAVE = "save"
+CONF_BAND_MODE = "band_mode"
 CONF_MIN_AUTH_MODE = "min_auth_mode"
 CONF_POST_CONNECT_ROAMING = "post_connect_roaming"
 
@@ -87,6 +96,13 @@ WIFI_POWER_SAVE_MODES = {
     "NONE": WiFiPowerSaveMode.WIFI_POWER_SAVE_NONE,
     "LIGHT": WiFiPowerSaveMode.WIFI_POWER_SAVE_LIGHT,
     "HIGH": WiFiPowerSaveMode.WIFI_POWER_SAVE_HIGH,
+}
+
+WiFiBandMode = cg.global_ns.enum("wifi_band_mode_t")
+WIFI_BAND_MODES = {
+    "AUTO": WiFiBandMode.WIFI_BAND_MODE_AUTO,
+    "2.4GHZ": WiFiBandMode.WIFI_BAND_MODE_2G_ONLY,
+    "5GHZ": WiFiBandMode.WIFI_BAND_MODE_5G_ONLY,
 }
 
 WifiMinAuthMode = wifi_ns.enum("WifiMinAuthMode")
@@ -150,6 +166,7 @@ TTLS_PHASE_2 = {
 }
 
 EAP_AUTH_SCHEMA = cv.All(
+    cv.only_on([Platform.ESP32, Platform.ESP8266]),
     cv.Schema(
         {
             cv.Optional(CONF_IDENTITY): cv.string_strict,
@@ -194,7 +211,13 @@ WIFI_NETWORK_AP = WIFI_NETWORK_BASE.extend(
 def wifi_network_ap(value):
     if value is None:
         value = {}
-    return WIFI_NETWORK_AP(value)
+    config = WIFI_NETWORK_AP(value)
+    if CONF_MANUAL_IP in config and CORE.is_rp2040:
+        raise cv.Invalid(
+            "Manual AP IP configuration is not supported on RP2040. "
+            "The AP uses the default IP 192.168.4.1"
+        )
+    return config
 
 
 WIFI_NETWORK_STA = WIFI_NETWORK_BASE.extend(
@@ -255,9 +278,28 @@ def final_validate(config):
         )
 
 
+def _consume_wifi_sockets(config: ConfigType) -> ConfigType:
+    """Register UDP PCBs used internally by lwIP for DHCP and DNS.
+
+    Only needed on LibreTiny where we directly set MEMP_NUM_UDP_PCB (the raw
+    PCB pool shared by both application sockets and lwIP internals like DHCP/DNS).
+    On ESP32, CONFIG_LWIP_MAX_SOCKETS only controls the POSIX socket layer —
+    DHCP/DNS use raw udp_new() which bypasses it entirely.
+    """
+    if not (CORE.is_bk72xx or CORE.is_rtl87xx or CORE.is_ln882x):
+        return config
+    from esphome.components import socket
+
+    # lwIP allocates UDP PCBs for DHCP client and DNS resolver internally.
+    # These are not application sockets but consume MEMP_NUM_UDP_PCB pool entries.
+    socket.consume_sockets(2, "wifi.lwip_internal", socket.SocketType.UDP)(config)
+    return config
+
+
 FINAL_VALIDATE_SCHEMA = cv.All(
     final_validate,
     validate_variant,
+    _consume_wifi_sockets,
 )
 
 
@@ -288,11 +330,6 @@ def _validate(config):
         config = config.copy()
         config[CONF_NETWORKS] = []
 
-    if config.get(CONF_FAST_CONNECT, False):
-        networks = config.get(CONF_NETWORKS, [])
-        if not networks:
-            raise cv.Invalid("At least one network required for fast_connect!")
-
     if CONF_USE_ADDRESS not in config:
         use_address = CORE.name + config[CONF_DOMAIN]
         if CONF_MANUAL_IP in config:
@@ -315,7 +352,6 @@ def _validate(config):
     return config
 
 
-CONF_OUTPUT_POWER = "output_power"
 CONF_PASSIVE_SCAN = "passive_scan"
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -356,6 +392,11 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.SplitDefault(CONF_ENABLE_RRM, esp32=False): cv.All(
                 cv.boolean, cv.only_on_esp32
+            ),
+            cv.Optional(CONF_BAND_MODE): cv.All(
+                cv.enum(WIFI_BAND_MODES, upper=True),
+                cv.only_on_esp32,
+                only_on_variant(supported=[const.VARIANT_ESP32C5]),
             ),
             cv.Optional(CONF_PASSIVE_SCAN, default=False): cv.boolean,
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
@@ -498,6 +539,13 @@ async def to_code(config):
         cg.add(var.set_passive_scan(True))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
+        if CORE.is_esp32:
+            # Set PHY max TX power to match output_power so calibration also uses
+            # reduced power. This prevents brownout during PHY init on marginal
+            # power supplies, which is critical for OTA updates with rollback enabled.
+            # Kconfig range is 10-20, ESPHome allows 8.5-20.5
+            phy_tx_power = max(10, min(20, math.ceil(config[CONF_OUTPUT_POWER])))
+            add_idf_sdkconfig_option("CONFIG_ESP_PHY_MAX_WIFI_TX_POWER", phy_tx_power)
     # enable_on_boot defaults to true in C++ - only set if false
     if not config[CONF_ENABLE_ON_BOOT]:
         cg.add(var.set_enable_on_boot(False))
@@ -524,6 +572,8 @@ async def to_code(config):
             cg.add(var.set_btm(config[CONF_ENABLE_BTM]))
         if config[CONF_ENABLE_RRM]:
             cg.add(var.set_rrm(config[CONF_ENABLE_RRM]))
+        if CONF_BAND_MODE in config:
+            cg.add(var.set_band_mode(config[CONF_BAND_MODE]))
 
     if config.get(CONF_USE_PSRAM):
         add_idf_sdkconfig_option("CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP", True)
@@ -585,11 +635,13 @@ async def to_code(config):
     await cg.past_safe_mode()
 
     if on_connect_config := config.get(CONF_ON_CONNECT):
+        cg.add_define("USE_WIFI_CONNECT_TRIGGER")
         await automation.build_automation(
             var.get_connect_trigger(), [], on_connect_config
         )
 
     if on_disconnect_config := config.get(CONF_ON_DISCONNECT):
+        cg.add_define("USE_WIFI_DISCONNECT_TRIGGER")
         await automation.build_automation(
             var.get_disconnect_trigger(), [], on_disconnect_config
         )
@@ -612,12 +664,16 @@ async def wifi_ap_active_to_code(config, condition_id, template_arg, args):
     return cg.new_Pvariable(condition_id, template_arg)
 
 
-@automation.register_action("wifi.enable", WiFiEnableAction, cv.Schema({}))
+@automation.register_action(
+    "wifi.enable", WiFiEnableAction, cv.Schema({}), synchronous=True
+)
 async def wifi_enable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
 
-@automation.register_action("wifi.disable", WiFiDisableAction, cv.Schema({}))
+@automation.register_action(
+    "wifi.disable", WiFiDisableAction, cv.Schema({}), synchronous=True
+)
 async def wifi_disable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
@@ -723,6 +779,7 @@ async def final_step():
             cv.Optional(CONF_ON_ERROR): automation.validate_automation(single=True),
         }
     ),
+    synchronous=False,
 )
 async def wifi_set_sta_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/components/wifi/automation.h
+++ b/components/wifi/automation.h
@@ -48,7 +48,7 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
     char ssid_buf[SSID_BUFFER_SIZE];
     if (strcmp(global_wifi_component->wifi_ssid_to(ssid_buf), ssid.c_str()) == 0) {
       // Callback to notify the user that the connection was successful
-      this->connect_trigger_->trigger();
+      this->connect_trigger_.trigger();
       return;
     }
     // Create a new WiFiAP object with the new SSID and password
@@ -79,13 +79,13 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
       // Start a timeout for the fallback if the connection to the old AP fails
       this->set_timeout("wifi-fallback-timeout", this->connection_timeout_.value(x...), [this]() {
         this->connecting_ = false;
-        this->error_trigger_->trigger();
+        this->error_trigger_.trigger();
       });
     });
   }
 
-  Trigger<> *get_connect_trigger() const { return this->connect_trigger_; }
-  Trigger<> *get_error_trigger() const { return this->error_trigger_; }
+  Trigger<> *get_connect_trigger() { return &this->connect_trigger_; }
+  Trigger<> *get_error_trigger() { return &this->error_trigger_; }
 
   void loop() override {
     if (!this->connecting_)
@@ -98,10 +98,10 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
       char ssid_buf[SSID_BUFFER_SIZE];
       if (strcmp(global_wifi_component->wifi_ssid_to(ssid_buf), this->new_sta_.get_ssid().c_str()) == 0) {
         // Callback to notify the user that the connection was successful
-        this->connect_trigger_->trigger();
+        this->connect_trigger_.trigger();
       } else {
         // Callback to notify the user that the connection failed
-        this->error_trigger_->trigger();
+        this->error_trigger_.trigger();
       }
     }
   }
@@ -110,8 +110,8 @@ template<typename... Ts> class WiFiConfigureAction : public Action<Ts...>, publi
   bool connecting_{false};
   WiFiAP new_sta_;
   WiFiAP old_sta_;
-  Trigger<> *connect_trigger_{new Trigger<>()};
-  Trigger<> *error_trigger_{new Trigger<>()};
+  Trigger<> connect_trigger_;
+  Trigger<> error_trigger_;
 };
 
 }  // namespace esphome::wifi

--- a/components/wifi/wifi_component.cpp
+++ b/components/wifi/wifi_component.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cinttypes>
 #include <cmath>
+#include <type_traits>
 
 #ifdef USE_ESP32
 #if (ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 1)
@@ -20,6 +21,7 @@
 #endif
 
 #include <algorithm>
+#include <new>
 #include <utility>
 #include "lwip/dns.h"
 #include "lwip/err.h"
@@ -39,9 +41,76 @@
 #include "esphome/components/esp32_improv/esp32_improv_component.h"
 #endif
 
+#ifdef USE_IMPROV_SERIAL
+#include "esphome/components/improv_serial/improv_serial_component.h"
+#endif
+
 namespace esphome::wifi {
 
 static const char *const TAG = "wifi";
+
+// CompactString implementation
+CompactString::CompactString(const char *str, size_t len) {
+  if (len > MAX_LENGTH) {
+    len = MAX_LENGTH;  // Clamp to max valid length
+  }
+
+  this->length_ = len;
+  if (len <= INLINE_CAPACITY) {
+    // Store inline with null terminator
+    this->is_heap_ = 0;
+    if (len > 0) {
+      std::memcpy(this->storage_, str, len);
+    }
+    this->storage_[len] = '\0';
+  } else {
+    // Heap allocate with null terminator
+    this->is_heap_ = 1;
+    char *heap_data = new char[len + 1];  // NOLINT(cppcoreguidelines-owning-memory)
+    std::memcpy(heap_data, str, len);
+    heap_data[len] = '\0';
+    this->set_heap_ptr_(heap_data);
+  }
+}
+
+CompactString::CompactString(const CompactString &other) : CompactString(other.data(), other.size()) {}
+
+CompactString &CompactString::operator=(const CompactString &other) {
+  if (this != &other) {
+    this->~CompactString();
+    new (this) CompactString(other);
+  }
+  return *this;
+}
+
+CompactString::CompactString(CompactString &&other) noexcept : length_(other.length_), is_heap_(other.is_heap_) {
+  // Copy full storage (includes null terminator for inline, or pointer for heap)
+  std::memcpy(this->storage_, other.storage_, INLINE_CAPACITY + 1);
+  other.length_ = 0;
+  other.is_heap_ = 0;
+  other.storage_[0] = '\0';
+}
+
+CompactString &CompactString::operator=(CompactString &&other) noexcept {
+  if (this != &other) {
+    this->~CompactString();
+    new (this) CompactString(std::move(other));
+  }
+  return *this;
+}
+
+CompactString::~CompactString() {
+  if (this->is_heap_) {
+    delete[] this->get_heap_ptr_();  // NOLINT(cppcoreguidelines-owning-memory)
+  }
+}
+
+bool CompactString::operator==(const CompactString &other) const {
+  return this->size() == other.size() && std::memcmp(this->data(), other.data(), this->size()) == 0;
+}
+bool CompactString::operator==(const StringRef &other) const {
+  return this->size() == other.size() && std::memcmp(this->data(), other.c_str(), this->size()) == 0;
+}
 
 /// WiFi Retry Logic - Priority-Based BSSID Selection
 ///
@@ -232,25 +301,23 @@ static const char *const TAG = "wifi";
 /// │  - Roaming fail (RECONNECTING→IDLE): counter preserved (ping-pong)   │
 /// └──────────────────────────────────────────────────────────────────────┘
 
+// Use if-chain instead of switch to avoid jump table in RODATA (wastes RAM on ESP8266)
 static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
-  switch (phase) {
-    case WiFiRetryPhase::INITIAL_CONNECT:
-      return LOG_STR("INITIAL_CONNECT");
+  if (phase == WiFiRetryPhase::INITIAL_CONNECT)
+    return LOG_STR("INITIAL_CONNECT");
 #ifdef USE_WIFI_FAST_CONNECT
-    case WiFiRetryPhase::FAST_CONNECT_CYCLING_APS:
-      return LOG_STR("FAST_CONNECT_CYCLING");
+  if (phase == WiFiRetryPhase::FAST_CONNECT_CYCLING_APS)
+    return LOG_STR("FAST_CONNECT_CYCLING");
 #endif
-    case WiFiRetryPhase::EXPLICIT_HIDDEN:
-      return LOG_STR("EXPLICIT_HIDDEN");
-    case WiFiRetryPhase::SCAN_CONNECTING:
-      return LOG_STR("SCAN_CONNECTING");
-    case WiFiRetryPhase::RETRY_HIDDEN:
-      return LOG_STR("RETRY_HIDDEN");
-    case WiFiRetryPhase::RESTARTING_ADAPTER:
-      return LOG_STR("RESTARTING");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  if (phase == WiFiRetryPhase::EXPLICIT_HIDDEN)
+    return LOG_STR("EXPLICIT_HIDDEN");
+  if (phase == WiFiRetryPhase::SCAN_CONNECTING)
+    return LOG_STR("SCAN_CONNECTING");
+  if (phase == WiFiRetryPhase::RETRY_HIDDEN)
+    return LOG_STR("RETRY_HIDDEN");
+  if (phase == WiFiRetryPhase::RESTARTING_ADAPTER)
+    return LOG_STR("RESTARTING");
+  return LOG_STR("UNKNOWN");
 }
 
 bool WiFiComponent::went_through_explicit_hidden_phase_() const {
@@ -347,22 +414,104 @@ bool WiFiComponent::needs_scan_results_() const {
   return this->scan_result_.empty() || !this->scan_result_[0].get_matches();
 }
 
-bool WiFiComponent::ssid_was_seen_in_scan_(const std::string &ssid) const {
+bool WiFiComponent::ssid_was_seen_in_scan_(const CompactString &ssid) const {
   // Check if this SSID is configured as hidden
   // If explicitly marked hidden, we should always try hidden mode regardless of scan results
   for (const auto &conf : this->sta_) {
-    if (conf.get_ssid() == ssid && conf.get_hidden()) {
+    if (conf.ssid_ == ssid && conf.get_hidden()) {
       return false;  // Treat as not seen - force hidden mode attempt
     }
   }
 
   // Otherwise, check if we saw it in scan results
   for (const auto &scan : this->scan_result_) {
-    if (scan.get_ssid() == ssid) {
+    if (scan.ssid_ == ssid) {
       return true;
     }
   }
   return false;
+}
+
+bool WiFiComponent::needs_full_scan_results_() const {
+  // Components that require full scan results (for example, scan result listeners)
+  // are expected to call request_wifi_scan_results(), which sets keep_scan_results_.
+  if (this->keep_scan_results_) {
+    return true;
+  }
+
+#ifdef USE_CAPTIVE_PORTAL
+  // Captive portal needs full results when active (showing network list to user)
+  if (captive_portal::global_captive_portal != nullptr && captive_portal::global_captive_portal->is_active()) {
+    return true;
+  }
+#endif
+
+#ifdef USE_IMPROV_SERIAL
+  // Improv serial needs results during provisioning (before connected)
+  if (improv_serial::global_improv_serial_component != nullptr && !this->is_connected()) {
+    return true;
+  }
+#endif
+
+#ifdef USE_IMPROV
+  // BLE improv also needs results during provisioning
+  if (esp32_improv::global_improv_component != nullptr && esp32_improv::global_improv_component->is_active()) {
+    return true;
+  }
+#endif
+
+  return false;
+}
+
+bool WiFiComponent::matches_configured_network_(const char *ssid, const uint8_t *bssid) const {
+  // Hidden networks in scan results have empty SSIDs - skip them
+  if (ssid[0] == '\0') {
+    return false;
+  }
+  for (const auto &sta : this->sta_) {
+    // Skip hidden network configs (they don't appear in normal scans)
+    if (sta.get_hidden()) {
+      continue;
+    }
+    // For BSSID-only configs (empty SSID), match by BSSID
+    if (sta.ssid_.empty()) {
+      if (sta.has_bssid() && std::memcmp(sta.get_bssid().data(), bssid, 6) == 0) {
+        return true;
+      }
+      continue;
+    }
+    // Match by SSID
+    if (sta.ssid_ == ssid) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void __attribute__((flatten)) WiFiComponent::set_sta_priority(bssid_t bssid, int8_t priority) {
+  for (auto &it : this->sta_priorities_) {
+    if (it.bssid == bssid) {
+      it.priority = priority;
+      return;
+    }
+  }
+  this->sta_priorities_.push_back(WiFiSTAPriority{
+      .bssid = bssid,
+      .priority = priority,
+  });
+}
+
+void WiFiComponent::log_discarded_scan_result_(const char *ssid, const uint8_t *bssid, int8_t rssi, uint8_t channel) {
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  // Skip logging during roaming scans to avoid log buffer overflow
+  // (roaming scans typically find many networks but only care about same-SSID APs)
+  if (this->roaming_state_ == RoamingState::SCANNING) {
+    return;
+  }
+  char bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  format_mac_addr_upper(bssid, bssid_s);
+  ESP_LOGV(TAG, "- " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") " %ddB Ch:%u", ssid, bssid_s, rssi, channel);
+#endif
 }
 
 int8_t WiFiComponent::find_next_hidden_sta_(int8_t start_index) {
@@ -394,18 +543,18 @@ int8_t WiFiComponent::find_next_hidden_sta_(int8_t start_index) {
     if (!include_explicit_hidden && sta.get_hidden()) {
       int8_t first_non_hidden_idx = this->find_first_non_hidden_index_();
       if (first_non_hidden_idx < 0 || static_cast<int8_t>(i) < first_non_hidden_idx) {
-        ESP_LOGD(TAG, "Skipping " LOG_SECRET("'%s'") " (explicit hidden, already tried)", sta.get_ssid().c_str());
+        ESP_LOGD(TAG, "Skipping " LOG_SECRET("'%s'") " (explicit hidden, already tried)", sta.ssid_.c_str());
         continue;
       }
     }
 
     // In BLIND_RETRY mode, treat all networks as candidates
     // In SCAN_BASED mode, only retry networks that weren't seen in the scan
-    if (this->retry_hidden_mode_ == RetryHiddenMode::BLIND_RETRY || !this->ssid_was_seen_in_scan_(sta.get_ssid())) {
-      ESP_LOGD(TAG, "Hidden candidate " LOG_SECRET("'%s'") " at index %d", sta.get_ssid().c_str(), static_cast<int>(i));
+    if (this->retry_hidden_mode_ == RetryHiddenMode::BLIND_RETRY || !this->ssid_was_seen_in_scan_(sta.ssid_)) {
+      ESP_LOGD(TAG, "Hidden candidate " LOG_SECRET("'%s'") " at index %d", sta.ssid_.c_str(), static_cast<int>(i));
       return static_cast<int8_t>(i);
     }
-    ESP_LOGD(TAG, "Skipping hidden retry for visible network " LOG_SECRET("'%s'"), sta.get_ssid().c_str());
+    ESP_LOGD(TAG, "Skipping hidden retry for visible network " LOG_SECRET("'%s'"), sta.ssid_.c_str());
   }
   // No hidden SSIDs found
   return -1;
@@ -522,11 +671,11 @@ void WiFiComponent::start() {
     // Fast connect optimization: only use when we have saved BSSID+channel data
     // Without saved data, try first configured network or use normal flow
     if (loaded_fast_connect) {
-      ESP_LOGI(TAG, "Starting fast_connect (saved) " LOG_SECRET("'%s'"), params.get_ssid().c_str());
+      ESP_LOGI(TAG, "Starting fast_connect (saved) " LOG_SECRET("'%s'"), params.ssid_.c_str());
       this->start_connecting(params);
     } else if (!this->sta_.empty() && !this->sta_[0].get_hidden()) {
       // No saved data, but have configured networks - try first non-hidden network
-      ESP_LOGI(TAG, "Starting fast_connect (config) " LOG_SECRET("'%s'"), this->sta_[0].get_ssid().c_str());
+      ESP_LOGI(TAG, "Starting fast_connect (config) " LOG_SECRET("'%s'"), this->sta_[0].ssid_.c_str());
       this->selected_sta_index_ = 0;
       params = this->build_params_for_current_phase_();
       this->start_connecting(params);
@@ -565,22 +714,35 @@ void WiFiComponent::start() {
 void WiFiComponent::restart_adapter() {
   ESP_LOGW(TAG, "Restarting adapter");
   this->wifi_mode_(false, {});
+  // Clear error flag here because restart_adapter() enters COOLDOWN state,
+  // and check_connecting_finished() is called after cooldown without going
+  // through start_connecting() first. Without this clear, stale errors would
+  // trigger spurious "failed (callback)" logs. The canonical clear location
+  // is in start_connecting(); this is the only exception to that pattern.
   this->error_from_callback_ = false;
 }
 
 void WiFiComponent::loop() {
   this->wifi_loop_();
   const uint32_t now = App.get_loop_component_start_time();
+  this->update_connected_state_();
 
   if (this->has_sta()) {
+#if defined(USE_WIFI_CONNECT_TRIGGER) || defined(USE_WIFI_DISCONNECT_TRIGGER)
     if (this->is_connected() != this->handled_connected_state_) {
+#ifdef USE_WIFI_DISCONNECT_TRIGGER
       if (this->handled_connected_state_) {
-        this->disconnect_trigger_->trigger();
-      } else {
-        this->connect_trigger_->trigger();
+        this->disconnect_trigger_.trigger();
       }
+#endif
+#ifdef USE_WIFI_CONNECT_TRIGGER
+      if (!this->handled_connected_state_) {
+        this->connect_trigger_.trigger();
+      }
+#endif
       this->handled_connected_state_ = this->is_connected();
     }
+#endif  // USE_WIFI_CONNECT_TRIGGER || USE_WIFI_DISCONNECT_TRIGGER
 
     switch (this->state_) {
       case WIFI_COMPONENT_STATE_COOLDOWN: {
@@ -615,11 +777,9 @@ void WiFiComponent::loop() {
       }
 
       case WIFI_COMPONENT_STATE_STA_CONNECTED: {
-        if (!this->is_connected()) {
+        if (!this->is_connected_()) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
-          // Clear error flag before reconnecting so first attempt is not seen as immediate failure
-          this->error_from_callback_ = false;
           this->retry_connect();
         } else {
           this->status_clear_warning();
@@ -649,14 +809,16 @@ void WiFiComponent::loop() {
 
 #ifdef USE_WIFI_AP
     if (this->has_ap() && !this->ap_setup_) {
-      // if (this->ap_timeout_ != 0 && (now - this->last_connected_ > this->ap_timeout_)) {
-        ESP_LOGI(TAG, "Starting fallback AP");
-        this->setup_ap_config_();
+      ESP_LOGI(TAG, "Starting fallback AP");
+      this->setup_ap_config_();
 #ifdef USE_CAPTIVE_PORTAL
-        if (captive_portal::global_captive_portal != nullptr)
-          captive_portal::global_captive_portal->start();
+      if (captive_portal::global_captive_portal != nullptr) {
+        // Reset so we force one full scan after captive portal starts
+        // (previous scans were filtered because captive portal wasn't active yet)
+        this->has_completed_scan_after_captive_portal_start_ = false;
+        captive_portal::global_captive_portal->start();
+      }
 #endif
-      // }
     }
 #endif  // USE_WIFI_AP
 
@@ -742,17 +904,33 @@ void WiFiComponent::setup_ap_config_() {
   if (this->ap_setup_)
     return;
 
-  if (this->ap_.get_ssid().empty()) {
-    std::string name = App.get_name();
-    if (name.length() > 32) {
+  if (this->ap_.ssid_.empty()) {
+    // Build AP SSID from app name without heap allocation
+    // WiFi SSID max is 32 bytes, with MAC suffix we keep first 25 + last 7
+    static constexpr size_t AP_SSID_MAX_LEN = 32;
+    static constexpr size_t AP_SSID_PREFIX_LEN = 25;
+    static constexpr size_t AP_SSID_SUFFIX_LEN = 7;
+
+    const auto &app_name = App.get_name();
+    const char *name_ptr = app_name.c_str();
+    size_t name_len = app_name.length();
+
+    if (name_len <= AP_SSID_MAX_LEN) {
+      // Name fits, use directly
+      this->ap_.set_ssid(name_ptr);
+    } else {
+      // Name too long, need to truncate into stack buffer
+      char ssid_buf[AP_SSID_MAX_LEN + 1];
       if (App.is_name_add_mac_suffix_enabled()) {
         // Keep first 25 chars and last 7 chars (MAC suffix), remove middle
-        name.erase(25, name.length() - 32);
+        memcpy(ssid_buf, name_ptr, AP_SSID_PREFIX_LEN);
+        memcpy(ssid_buf + AP_SSID_PREFIX_LEN, name_ptr + name_len - AP_SSID_SUFFIX_LEN, AP_SSID_SUFFIX_LEN);
       } else {
-        name.resize(32);
+        memcpy(ssid_buf, name_ptr, AP_SSID_MAX_LEN);
       }
+      ssid_buf[AP_SSID_MAX_LEN] = '\0';
+      this->ap_.set_ssid(ssid_buf);
     }
-    this->ap_.set_ssid(name);
   }
   this->ap_setup_ = this->wifi_start_ap_(this->ap_);
 
@@ -762,7 +940,7 @@ void WiFiComponent::setup_ap_config_() {
                 "  AP SSID: '%s'\n"
                 "  AP Password: '%s'\n"
                 "  IP Address: %s",
-                this->ap_.get_ssid().c_str(), this->ap_.get_password().c_str(), this->wifi_soft_ap_ip().str_to(ip_buf));
+                this->ap_.ssid_.c_str(), this->ap_.password_.c_str(), this->wifi_soft_ap_ip().str_to(ip_buf));
 
 #ifdef USE_WIFI_MANUAL_IP
   auto manual_ip = this->ap_.get_manual_ip();
@@ -790,9 +968,11 @@ void WiFiComponent::set_ap(const WiFiAP &ap) {
 }
 #endif  // USE_WIFI_AP
 
+#ifdef USE_LOOP_PRIORITY
 float WiFiComponent::get_loop_priority() const {
   return 10.0f;  // before other loop components
 }
+#endif
 
 void WiFiComponent::init_sta(size_t count) { this->sta_.init(count); }
 void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
@@ -859,9 +1039,12 @@ WiFiAP WiFiComponent::get_sta() const {
   return config ? *config : WiFiAP{};
 }
 void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &password) {
+  this->save_wifi_sta(ssid.c_str(), password.c_str());
+}
+void WiFiComponent::save_wifi_sta(const char *ssid, const char *password) {
   SavedWifiSettings save{};  // zero-initialized - all bytes set to \0, guaranteeing null termination
-  strncpy(save.ssid, ssid.c_str(), sizeof(save.ssid) - 1);              // max 32 chars, byte 32 remains \0
-  strncpy(save.password, password.c_str(), sizeof(save.password) - 1);  // max 64 chars, byte 64 remains \0
+  strncpy(save.ssid, ssid, sizeof(save.ssid) - 1);              // max 32 chars, byte 32 remains \0
+  strncpy(save.password, password, sizeof(save.password) - 1);  // max 64 chars, byte 64 remains \0
   this->pref_.save(&save);
   // ensure it's written immediately
   global_preferences->sync();
@@ -895,14 +1078,14 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
 
   ESP_LOGI(TAG,
            "Connecting to " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") " (priority %d, attempt %u/%u in phase %s)...",
-           ap.get_ssid().c_str(), ap.has_bssid() ? bssid_s : LOG_STR_LITERAL("any"), priority, this->num_retried_ + 1,
+           ap.ssid_.c_str(), ap.has_bssid() ? bssid_s : LOG_STR_LITERAL("any"), priority, this->num_retried_ + 1,
            get_max_retries_for_phase(this->retry_phase_), LOG_STR_ARG(retry_phase_to_log_string(this->retry_phase_)));
 
 #ifdef ESPHOME_LOG_HAS_VERBOSE
   ESP_LOGV(TAG,
            "Connection Params:\n"
            "  SSID: '%s'",
-           ap.get_ssid().c_str());
+           ap.ssid_.c_str());
   if (ap.has_bssid()) {
     ESP_LOGV(TAG, "  BSSID: %s", bssid_s);
   } else {
@@ -910,8 +1093,9 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
   }
 
 #ifdef USE_WIFI_WPA2_EAP
-  if (ap.get_eap().has_value()) {
-    EAPAuth eap_config = ap.get_eap().value();
+  auto eap_opt = ap.get_eap();
+  if (eap_opt.has_value()) {
+    EAPAuth eap_config = *eap_opt;
     // clang-format off
     ESP_LOGV(
         TAG,
@@ -935,7 +1119,7 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
              client_key_present ? "present" : "not present");
   } else {
 #endif
-    ESP_LOGV(TAG, "  Password: " LOG_SECRET("'%s'"), ap.get_password().c_str());
+    ESP_LOGV(TAG, "  Password: " LOG_SECRET("'%s'"), ap.password_.c_str());
 #ifdef USE_WIFI_WPA2_EAP
   }
 #endif
@@ -945,8 +1129,9 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
     ESP_LOGV(TAG, "  Channel not set");
   }
 #ifdef USE_WIFI_MANUAL_IP
-  if (ap.get_manual_ip().has_value()) {
-    ManualIP m = *ap.get_manual_ip();
+  auto manual_ip = ap.get_manual_ip();
+  if (manual_ip.has_value()) {
+    ManualIP m = *manual_ip;
     char static_ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
     char gateway_buf[network::IP_ADDRESS_BUFFER_SIZE];
     char subnet_buf[network::IP_ADDRESS_BUFFER_SIZE];
@@ -962,6 +1147,12 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
   }
   ESP_LOGV(TAG, "  Hidden: %s", YESNO(ap.get_hidden()));
 #endif
+
+  // Clear any stale error from previous connection attempt.
+  // This is the canonical location for clearing the flag since all connection
+  // attempts go through start_connecting(). The only other clear is in
+  // restart_adapter() which enters COOLDOWN without calling start_connecting().
+  this->error_from_callback_ = false;
 
   if (!this->wifi_sta_connect_(ap)) {
     ESP_LOGE(TAG, "wifi_sta_connect_ failed");
@@ -1068,7 +1259,6 @@ void WiFiComponent::enable() {
     return;
 
   ESP_LOGD(TAG, "Enabling");
-  this->error_from_callback_ = false;
   this->state_ = WIFI_COMPONENT_STATE_OFF;
   this->start();
 }
@@ -1146,20 +1336,61 @@ void WiFiComponent::start_scanning() {
 // Using insertion sort instead of std::stable_sort saves flash memory
 // by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)
 // IMPORTANT: This sort is stable (preserves relative order of equal elements)
+//
+// Uses raw memcpy instead of copy assignment to avoid CompactString's
+// destructor/constructor overhead (heap delete[]/new[] for long SSIDs).
+// Copy assignment calls ~CompactString() then placement-new for every shift,
+// which means delete[]/new[] per shift for heap-allocated SSIDs. With 70+
+// networks (e.g., captive portal showing full scan results), this caused
+// event loop blocking from hundreds of heap operations in a tight loop.
+//
+// This is safe because we're permuting elements within the same array —
+// each slot is overwritten exactly once, so no ownership duplication occurs.
+// All members of WiFiScanResult are either trivially copyable (bssid, channel,
+// rssi, priority, flags) or CompactString, which stores either inline data or
+// a heap pointer — never a self-referential pointer (unlike std::string's SSO
+// on some implementations). This was not possible before PR#13472 replaced
+// std::string with CompactString, since std::string's internal layout is
+// implementation-defined and may use self-referential pointers.
+//
+// TODO: If C++ standardizes std::trivially_relocatable, add the assertion for
+// WiFiScanResult/CompactString here to formally express the memcpy safety guarantee.
 template<typename VectorType> static void insertion_sort_scan_results(VectorType &results) {
+  // memcpy-based sort requires no self-referential pointers or virtual dispatch.
+  // These static_asserts guard the assumptions. If any fire, the memcpy sort
+  // must be reviewed for safety before updating the expected values.
+  //
+  // No vtable pointers (memcpy would corrupt vptr)
+  static_assert(!std::is_polymorphic<WiFiScanResult>::value, "WiFiScanResult must not have vtable");
+  static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable");
+  // Standard layout ensures predictable memory layout with no virtual bases
+  // and no mixed-access-specifier reordering
+  static_assert(std::is_standard_layout<WiFiScanResult>::value, "WiFiScanResult must be standard layout");
+  static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout");
+  // Size checks catch added/removed fields that may need safety review
+  static_assert(sizeof(WiFiScanResult) == 32, "WiFiScanResult size changed - verify memcpy sort is still safe");
+  static_assert(sizeof(CompactString) == 20, "CompactString size changed - verify memcpy sort is still safe");
+  // Alignment must match for reinterpret_cast of key_buf to be valid
+  static_assert(alignof(WiFiScanResult) <= alignof(std::max_align_t), "WiFiScanResult alignment exceeds max_align_t");
   const size_t size = results.size();
+  constexpr size_t elem_size = sizeof(WiFiScanResult);
+  // Suppress warnings for intentional memcpy on non-trivially-copyable type.
+  // Safety is guaranteed by the static_asserts above and the permutation invariant.
+  // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
+  auto *memcpy_fn = &memcpy;
   for (size_t i = 1; i < size; i++) {
-    // Make a copy to avoid issues with move semantics during comparison
-    WiFiScanResult key = results[i];
+    alignas(WiFiScanResult) uint8_t key_buf[elem_size];
+    memcpy_fn(key_buf, &results[i], elem_size);
+    const auto &key = *reinterpret_cast<const WiFiScanResult *>(key_buf);
     int32_t j = i - 1;
 
     // Move elements that are worse than key to the right
     // For stability, we only move if key is strictly better than results[j]
     while (j >= 0 && wifi_scan_result_is_better(key, results[j])) {
-      results[j + 1] = results[j];
+      memcpy_fn(&results[j + 1], &results[j], elem_size);
       j--;
     }
-    results[j + 1] = key;
+    memcpy_fn(&results[j + 1], key_buf, elem_size);
   }
 }
 
@@ -1171,7 +1402,7 @@ template<typename VectorType> static void insertion_sort_scan_results(VectorType
 // has overhead from UART transmission, so combining INFO+DEBUG into one line halves
 // the blocking time. Do NOT split this into separate ESP_LOGI/ESP_LOGD calls.
 __attribute__((noinline)) static void log_scan_result(const WiFiScanResult &res) {
-  char bssid_s[18];
+  char bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
   auto bssid = res.get_bssid();
   format_mac_addr_upper(bssid.data(), bssid_s);
 
@@ -1187,18 +1418,6 @@ __attribute__((noinline)) static void log_scan_result(const WiFiScanResult &res)
 #endif
 }
 
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-// Helper function to log non-matching scan results at verbose level
-__attribute__((noinline)) static void log_scan_result_non_matching(const WiFiScanResult &res) {
-  char bssid_s[18];
-  auto bssid = res.get_bssid();
-  format_mac_addr_upper(bssid.data(), bssid_s);
-
-  ESP_LOGV(TAG, "- " LOG_SECRET("'%s'") " " LOG_SECRET("(%s) ") "%s", res.get_ssid().c_str(), bssid_s,
-           LOG_STR_ARG(get_signal_bars(res.get_rssi())));
-}
-#endif
-
 void WiFiComponent::check_scanning_finished() {
   if (!this->scan_done_) {
     if (millis() - this->action_started_ > WIFI_SCAN_TIMEOUT_MS) {
@@ -1208,6 +1427,8 @@ void WiFiComponent::check_scanning_finished() {
     return;
   }
   this->scan_done_ = false;
+  this->has_completed_scan_after_captive_portal_start_ =
+      true;  // Track that we've done a scan since captive portal started
   this->retry_hidden_mode_ = RetryHiddenMode::SCAN_BASED;
 
   if (this->scan_result_.empty()) {
@@ -1235,20 +1456,11 @@ void WiFiComponent::check_scanning_finished() {
   // Sort scan results using insertion sort for better memory efficiency
   insertion_sort_scan_results(this->scan_result_);
 
-  size_t non_matching_count = 0;
+  // Log matching networks (non-matching already logged at VERBOSE in scan callback)
   for (auto &res : this->scan_result_) {
     if (res.get_matches()) {
       log_scan_result(res);
-    } else {
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-      log_scan_result_non_matching(res);
-#else
-      non_matching_count++;
-#endif
     }
-  }
-  if (non_matching_count > 0) {
-    ESP_LOGD(TAG, "- %zu non-matching (VERBOSE to show)", non_matching_count);
   }
 
   // SYNCHRONIZATION POINT: Establish link between scan_result_[0] and selected_sta_index_
@@ -1302,6 +1514,22 @@ void WiFiComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Disabled");
     return;
   }
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+  const char *band_mode_s;
+  switch (this->band_mode_) {
+    case WIFI_BAND_MODE_2G_ONLY:
+      band_mode_s = "2.4GHz";
+      break;
+    case WIFI_BAND_MODE_5G_ONLY:
+      band_mode_s = "5GHz";
+      break;
+    case WIFI_BAND_MODE_AUTO:
+    default:
+      band_mode_s = "Auto";
+      break;
+  }
+  ESP_LOGCONFIG(TAG, "  Band Mode: %s", band_mode_s);
+#endif
   if (this->is_connected()) {
     this->print_connect_params_();
   }
@@ -1324,24 +1552,17 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     if (const WiFiAP *config = this->get_selected_sta_(); this->retry_phase_ == WiFiRetryPhase::RETRY_HIDDEN &&
                                                           config && !config->get_hidden() &&
                                                           this->scan_result_.empty()) {
-      ESP_LOGW(TAG, LOG_SECRET("'%s'") " should be marked hidden", config->get_ssid().c_str());
+      ESP_LOGW(TAG, LOG_SECRET("'%s'") " should be marked hidden", config->ssid_.c_str());
     }
     // Reset to initial phase on successful connection (don't log transition, just reset state)
     this->retry_phase_ = WiFiRetryPhase::INITIAL_CONNECT;
     this->num_retried_ = 0;
-    // Ensure next connection attempt does not inherit error state
-    // so when WiFi disconnects later we start fresh and don't see
-    // the first connection as a failure.
-    this->error_from_callback_ = false;
-
     if (this->has_ap()) {
 #ifdef USE_CAPTIVE_PORTAL
       if (this->is_captive_portal_active_()) {
         captive_portal::global_captive_portal->end();
       }
 #endif
-      // ESP_LOGD(TAG, "Disabling AP");
-      // this->wifi_mode_({}, false);
       ESP_LOGD(TAG, "Keeping AP enabled (AP+STA)");
     }
 #ifdef USE_IMPROV
@@ -1381,6 +1602,20 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
 
     this->release_scan_results_();
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+    // Notify listeners now that state machine has reached STA_CONNECTED
+    // This ensures wifi.connected condition returns true in listener automations
+    this->notify_connect_state_listeners_();
+#endif
+
+#if defined(USE_ESP8266) && defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
+    // On ESP8266, GOT_IP event may not fire for static IP configurations,
+    // so notify IP state listeners here as a fallback.
+    if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
+      this->notify_ip_state_listeners_();
+    }
+#endif
+
     return;
   }
 
@@ -1392,7 +1627,11 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
   }
 
   if (this->error_from_callback_) {
+    // ESP8266: logging done in callback, listeners deferred via pending_.disconnect
+    // Other platforms: just log generic failure message
+#ifndef USE_ESP8266
     ESP_LOGW(TAG, "Connecting to network failed (callback)");
+#endif
     this->retry_connect();
     return;
   }
@@ -1514,7 +1753,10 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       if (this->went_through_explicit_hidden_phase_()) {
         return WiFiRetryPhase::EXPLICIT_HIDDEN;
       }
-      // Skip scanning when captive portal/improv is active to avoid disrupting AP.
+      // Skip scanning when captive portal/improv is active to avoid disrupting AP,
+      // BUT only if we've already completed at least one scan AFTER the portal started.
+      // When captive portal first starts, scan results may be filtered/stale, so we need
+      // to do one full scan to populate available networks for the captive portal UI.
       //
       // WHY SCANNING DISRUPTS AP MODE:
       // WiFi scanning requires the radio to leave the AP's channel and hop through
@@ -1531,7 +1773,16 @@ WiFiRetryPhase WiFiComponent::determine_next_phase_() {
       //
       // This allows users to configure WiFi via captive portal while the device keeps
       // attempting to connect to all configured networks in sequence.
-      if (this->is_captive_portal_active_() || this->is_esp32_improv_active_()) {
+      // Captive portal needs scan results to show available networks.
+      // If captive portal is active, only skip scanning if we've done a scan after it started.
+      // If only improv is active (no captive portal), skip scanning since improv doesn't need results.
+      if (this->is_captive_portal_active_()) {
+        if (this->has_completed_scan_after_captive_portal_start_) {
+          return WiFiRetryPhase::RETRY_HIDDEN;
+        }
+        // Need to scan for captive portal
+      } else if (this->is_esp32_improv_active_()) {
+        // Improv doesn't need scan results
         return WiFiRetryPhase::RETRY_HIDDEN;
       }
       return WiFiRetryPhase::SCAN_CONNECTING;
@@ -1714,11 +1965,11 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
   }
 
   // Get SSID for logging (use pointer to avoid copy)
-  const std::string *ssid = nullptr;
+  const char *ssid = nullptr;
   if (this->retry_phase_ == WiFiRetryPhase::SCAN_CONNECTING && !this->scan_result_.empty()) {
-    ssid = &this->scan_result_[0].get_ssid();
+    ssid = this->scan_result_[0].ssid_.c_str();
   } else if (const WiFiAP *config = this->get_selected_sta_()) {
-    ssid = &config->get_ssid();
+    ssid = config->ssid_.c_str();
   }
 
   // Only decrease priority on the last attempt for this phase
@@ -1738,8 +1989,8 @@ void WiFiComponent::log_and_adjust_priority_for_failed_connect_() {
   }
   char bssid_s[18];
   format_mac_addr_upper(failed_bssid.value().data(), bssid_s);
-  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d",
-           ssid != nullptr ? ssid->c_str() : "", bssid_s, old_priority, new_priority);
+  ESP_LOGD(TAG, "Failed " LOG_SECRET("'%s'") " " LOG_SECRET("(%s)") ", priority %d → %d", ssid != nullptr ? ssid : "",
+           bssid_s, old_priority, new_priority);
 
   // After adjusting priority, check if all priorities are now at minimum
   // If so, clear the vector to save memory and reset for fresh start
@@ -1845,8 +2096,6 @@ void WiFiComponent::retry_connect() {
     this->advance_to_next_target_or_increment_retry_();
   }
 
-  this->error_from_callback_ = false;
-
   yield();
   // Check if we have a valid target before building params
   // After exhausting all networks in a phase, selected_sta_index_ may be -1
@@ -1857,25 +2106,12 @@ void WiFiComponent::retry_connect() {
   }
 }
 
-#ifdef USE_RP2040
-// RP2040's mDNS library (LEAmDNS) relies on LwipIntf::stateUpCB() to restart
-// mDNS when the network interface reconnects. However, this callback is disabled
-// in the arduino-pico framework. As a workaround, we block component setup until
-// WiFi is connected, ensuring mDNS.begin() is called with an active connection.
-
-bool WiFiComponent::can_proceed() {
-  if (!this->has_sta() || this->state_ == WIFI_COMPONENT_STATE_DISABLED || this->ap_setup_) {
-    return true;
-  }
-  return this->is_connected();
-}
-#endif
-
 void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
-bool WiFiComponent::is_connected() {
+bool WiFiComponent::is_connected_() const {
   return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
          this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
 }
+void WiFiComponent::update_connected_state_() { this->connected_ = this->is_connected_(); }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
@@ -1989,10 +2225,14 @@ void WiFiComponent::save_fast_connect_settings_() {
 }
 #endif
 
-void WiFiAP::set_ssid(const std::string &ssid) { this->ssid_ = ssid; }
+void WiFiAP::set_ssid(const std::string &ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
+void WiFiAP::set_ssid(const char *ssid) { this->ssid_ = CompactString(ssid, strlen(ssid)); }
 void WiFiAP::set_bssid(const bssid_t &bssid) { this->bssid_ = bssid; }
 void WiFiAP::clear_bssid() { this->bssid_ = {}; }
-void WiFiAP::set_password(const std::string &password) { this->password_ = password; }
+void WiFiAP::set_password(const std::string &password) {
+  this->password_ = CompactString(password.c_str(), password.size());
+}
+void WiFiAP::set_password(const char *password) { this->password_ = CompactString(password, strlen(password)); }
 #ifdef USE_WIFI_WPA2_EAP
 void WiFiAP::set_eap(optional<EAPAuth> eap_auth) { this->eap_ = std::move(eap_auth); }
 #endif
@@ -2002,10 +2242,8 @@ void WiFiAP::clear_channel() { this->channel_ = 0; }
 void WiFiAP::set_manual_ip(optional<ManualIP> manual_ip) { this->manual_ip_ = manual_ip; }
 #endif
 void WiFiAP::set_hidden(bool hidden) { this->hidden_ = hidden; }
-const std::string &WiFiAP::get_ssid() const { return this->ssid_; }
 const bssid_t &WiFiAP::get_bssid() const { return this->bssid_; }
 bool WiFiAP::has_bssid() const { return this->bssid_ != bssid_t{}; }
-const std::string &WiFiAP::get_password() const { return this->password_; }
 #ifdef USE_WIFI_WPA2_EAP
 const optional<EAPAuth> &WiFiAP::get_eap() const { return this->eap_; }
 #endif
@@ -2016,12 +2254,12 @@ const optional<ManualIP> &WiFiAP::get_manual_ip() const { return this->manual_ip
 #endif
 bool WiFiAP::get_hidden() const { return this->hidden_; }
 
-WiFiScanResult::WiFiScanResult(const bssid_t &bssid, std::string ssid, uint8_t channel, int8_t rssi, bool with_auth,
-                               bool is_hidden)
+WiFiScanResult::WiFiScanResult(const bssid_t &bssid, const char *ssid, size_t ssid_len, uint8_t channel, int8_t rssi,
+                               bool with_auth, bool is_hidden)
     : bssid_(bssid),
       channel_(channel),
       rssi_(rssi),
-      ssid_(std::move(ssid)),
+      ssid_(ssid, ssid_len),
       with_auth_(with_auth),
       is_hidden_(is_hidden) {}
 bool WiFiScanResult::matches(const WiFiAP &config) const {
@@ -2030,9 +2268,9 @@ bool WiFiScanResult::matches(const WiFiAP &config) const {
     // don't match SSID
     if (!this->is_hidden_)
       return false;
-  } else if (!config.get_ssid().empty()) {
+  } else if (!config.ssid_.empty()) {
     // check if SSID matches
-    if (config.get_ssid() != this->ssid_)
+    if (this->ssid_ != config.ssid_)
       return false;
   } else {
     // network is configured without SSID - match other settings
@@ -2043,15 +2281,15 @@ bool WiFiScanResult::matches(const WiFiAP &config) const {
 
 #ifdef USE_WIFI_WPA2_EAP
   // BSSID requires auth but no PSK or EAP credentials given
-  if (this->with_auth_ && (config.get_password().empty() && !config.get_eap().has_value()))
+  if (this->with_auth_ && (config.password_.empty() && !config.get_eap().has_value()))
     return false;
 
   // BSSID does not require auth, but PSK or EAP credentials given
-  if (!this->with_auth_ && (!config.get_password().empty() || config.get_eap().has_value()))
+  if (!this->with_auth_ && (!config.password_.empty() || config.get_eap().has_value()))
     return false;
 #else
   // If PSK given, only match for networks with auth (and vice versa)
-  if (config.get_password().empty() == this->with_auth_)
+  if (config.password_.empty() == this->with_auth_)
     return false;
 #endif
 
@@ -2064,7 +2302,6 @@ bool WiFiScanResult::matches(const WiFiAP &config) const {
 bool WiFiScanResult::get_matches() const { return this->matches_; }
 void WiFiScanResult::set_matches(bool matches) { this->matches_ = matches; }
 const bssid_t &WiFiScanResult::get_bssid() const { return this->bssid_; }
-const std::string &WiFiScanResult::get_ssid() const { return this->ssid_; }
 uint8_t WiFiScanResult::get_channel() const { return this->channel_; }
 int8_t WiFiScanResult::get_rssi() const { return this->rssi_; }
 bool WiFiScanResult::get_with_auth() const { return this->with_auth_; }
@@ -2080,7 +2317,7 @@ void WiFiComponent::clear_roaming_state_() {
 
 void WiFiComponent::release_scan_results_() {
   if (!this->keep_scan_results_) {
-#ifdef USE_RP2040
+#if defined(USE_RP2040) || defined(USE_ESP32)
     // std::vector - use swap trick since shrink_to_fit is non-binding
     decltype(this->scan_result_)().swap(this->scan_result_);
 #else
@@ -2089,6 +2326,44 @@ void WiFiComponent::release_scan_results_() {
 #endif
   }
 }
+
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+void WiFiComponent::notify_connect_state_listeners_() {
+  if (!this->pending_.connect_state)
+    return;
+  this->pending_.connect_state = false;
+  // Get current SSID and BSSID from the WiFi driver
+  char ssid_buf[SSID_BUFFER_SIZE];
+  const char *ssid = this->wifi_ssid_to(ssid_buf);
+  bssid_t bssid = this->wifi_bssid();
+  for (auto *listener : this->connect_state_listeners_) {
+    listener->on_wifi_connect_state(StringRef(ssid, strlen(ssid)), bssid);
+  }
+}
+
+void WiFiComponent::notify_disconnect_state_listeners_() {
+  constexpr uint8_t empty_bssid[6] = {};
+  for (auto *listener : this->connect_state_listeners_) {
+    listener->on_wifi_connect_state(StringRef(), empty_bssid);
+  }
+}
+#endif  // USE_WIFI_CONNECT_STATE_LISTENERS
+
+#ifdef USE_WIFI_IP_STATE_LISTENERS
+void WiFiComponent::notify_ip_state_listeners_() {
+  for (auto *listener : this->ip_state_listeners_) {
+    listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
+  }
+}
+#endif  // USE_WIFI_IP_STATE_LISTENERS
+
+#ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
+void WiFiComponent::notify_scan_results_listeners_() {
+  for (auto *listener : this->scan_results_listeners_) {
+    listener->on_wifi_scan_results(this->scan_result_);
+  }
+}
+#endif  // USE_WIFI_SCAN_RESULTS_LISTENERS
 
 void WiFiComponent::check_roaming_(uint32_t now) {
   // Guard: not for hidden networks (may not appear in scan)
@@ -2137,7 +2412,7 @@ void WiFiComponent::process_roaming_scan_() {
 
   for (const auto &result : this->scan_result_) {
     // Must be same SSID, different BSSID
-    if (current_ssid != result.get_ssid() || result.get_bssid() == current_bssid)
+    if (result.ssid_ != current_ssid || result.get_bssid() == current_bssid)
       continue;
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
@@ -2172,7 +2447,6 @@ void WiFiComponent::process_roaming_scan_() {
   this->roaming_state_ = RoamingState::CONNECTING;
 
   // Connect directly - wifi_sta_connect_ handles disconnect internally
-  this->error_from_callback_ = false;
   this->start_connecting(roam_params);
 }
 

--- a/components/wifi/wifi_component.h
+++ b/components/wifi/wifi_component.h
@@ -10,6 +10,7 @@
 
 #include <span>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #ifdef USE_LIBRETINY
@@ -43,6 +44,10 @@ extern "C" {
 }
 
 #include <WiFi.h>
+#endif
+
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+#include <esp_wifi_types.h>
 #endif
 
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
@@ -161,20 +166,86 @@ struct EAPAuth {
 
 using bssid_t = std::array<uint8_t, 6>;
 
-// Use std::vector for RP2040 since scan count is unknown (callback-based)
-// Use FixedVector for other platforms where count is queried first
-#ifdef USE_RP2040
+/// Initial reserve size for filtered scan results (typical: 1-3 matching networks per SSID)
+static constexpr size_t WIFI_SCAN_RESULT_FILTERED_RESERVE = 8;
+
+// Use std::vector for RP2040 (callback-based) and ESP32 (destructive scan API)
+// Use FixedVector for ESP8266 and LibreTiny where two-pass exact allocation is possible
+#if defined(USE_RP2040) || defined(USE_ESP32)
 template<typename T> using wifi_scan_vector_t = std::vector<T>;
 #else
 template<typename T> using wifi_scan_vector_t = FixedVector<T>;
 #endif
 
+/// 20-byte string: 18 chars inline + null, heap for longer. Always null-terminated.
+/// Used internally for WiFi SSID/password storage to reduce heap fragmentation.
+class CompactString {
+ public:
+  static constexpr uint8_t MAX_LENGTH = 127;
+  static constexpr uint8_t INLINE_CAPACITY = 18;  // 18 chars + null terminator fits in 19 bytes
+
+  CompactString() : length_(0), is_heap_(0) { this->storage_[0] = '\0'; }
+  CompactString(const char *str, size_t len);
+  CompactString(const CompactString &other);
+  CompactString(CompactString &&other) noexcept;
+  CompactString &operator=(const CompactString &other);
+  CompactString &operator=(CompactString &&other) noexcept;
+  ~CompactString();
+
+  const char *data() const { return this->is_heap_ ? this->get_heap_ptr_() : this->storage_; }
+  const char *c_str() const { return this->data(); }  // Always null-terminated
+  size_t size() const { return this->length_; }
+  bool empty() const { return this->length_ == 0; }
+
+  /// Return a StringRef view of this string (zero-copy)
+  StringRef ref() const { return StringRef(this->data(), this->size()); }
+
+  bool operator==(const CompactString &other) const;
+  bool operator!=(const CompactString &other) const { return !(*this == other); }
+  bool operator==(const StringRef &other) const;
+  bool operator!=(const StringRef &other) const { return !(*this == other); }
+  bool operator==(const char *other) const { return *this == StringRef(other); }
+  bool operator!=(const char *other) const { return !(*this == other); }
+
+ protected:
+  char *get_heap_ptr_() const {
+    char *ptr;
+    std::memcpy(&ptr, this->storage_, sizeof(ptr));
+    return ptr;
+  }
+  void set_heap_ptr_(char *ptr) { std::memcpy(this->storage_, &ptr, sizeof(ptr)); }
+
+  // Storage for string data. When is_heap_=0, contains the string directly (null-terminated).
+  // When is_heap_=1, first sizeof(char*) bytes contain pointer to heap allocation.
+  char storage_[INLINE_CAPACITY + 1];  // 19 bytes: 18 chars + null terminator
+  uint8_t length_ : 7;                 // String length (0-127)
+  uint8_t is_heap_ : 1;                // 1 if using heap pointer, 0 if using inline storage
+  // Total size: 20 bytes (19 bytes storage + 1 byte bitfields)
+};
+
+static_assert(sizeof(CompactString) == 20, "CompactString must be exactly 20 bytes");
+// CompactString is not trivially copyable (non-trivial destructor/copy for heap case).
+// However, its layout has no self-referential pointers: storage_[] contains either inline
+// data or an external heap pointer — never a pointer to itself. This is unlike libstdc++
+// std::string SSO where _M_p points to _M_local_buf within the same object.
+// This property allows memcpy-based permutation sorting where each element ends up in
+// exactly one slot (no ownership duplication). These asserts document that layout property.
+static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout");
+static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable");
+
 class WiFiAP {
+  friend class WiFiComponent;
+  friend class WiFiScanResult;
+
  public:
   void set_ssid(const std::string &ssid);
+  void set_ssid(const char *ssid);
+  void set_ssid(StringRef ssid) { this->ssid_ = CompactString(ssid.c_str(), ssid.size()); }
   void set_bssid(const bssid_t &bssid);
   void clear_bssid();
   void set_password(const std::string &password);
+  void set_password(const char *password);
+  void set_password(StringRef password) { this->password_ = CompactString(password.c_str(), password.size()); }
 #ifdef USE_WIFI_WPA2_EAP
   void set_eap(optional<EAPAuth> eap_auth);
 #endif  // USE_WIFI_WPA2_EAP
@@ -185,10 +256,10 @@ class WiFiAP {
   void set_manual_ip(optional<ManualIP> manual_ip);
 #endif
   void set_hidden(bool hidden);
-  const std::string &get_ssid() const;
+  StringRef get_ssid() const { return this->ssid_.ref(); }
+  StringRef get_password() const { return this->password_.ref(); }
   const bssid_t &get_bssid() const;
   bool has_bssid() const;
-  const std::string &get_password() const;
 #ifdef USE_WIFI_WPA2_EAP
   const optional<EAPAuth> &get_eap() const;
 #endif  // USE_WIFI_WPA2_EAP
@@ -201,8 +272,8 @@ class WiFiAP {
   bool get_hidden() const;
 
  protected:
-  std::string ssid_;
-  std::string password_;
+  CompactString ssid_;
+  CompactString password_;
 #ifdef USE_WIFI_WPA2_EAP
   optional<EAPAuth> eap_;
 #endif  // USE_WIFI_WPA2_EAP
@@ -217,15 +288,18 @@ class WiFiAP {
 };
 
 class WiFiScanResult {
+  friend class WiFiComponent;
+
  public:
-  WiFiScanResult(const bssid_t &bssid, std::string ssid, uint8_t channel, int8_t rssi, bool with_auth, bool is_hidden);
+  WiFiScanResult(const bssid_t &bssid, const char *ssid, size_t ssid_len, uint8_t channel, int8_t rssi, bool with_auth,
+                 bool is_hidden);
 
   bool matches(const WiFiAP &config) const;
 
   bool get_matches() const;
   void set_matches(bool matches);
   const bssid_t &get_bssid() const;
-  const std::string &get_ssid() const;
+  StringRef get_ssid() const { return this->ssid_.ref(); }
   uint8_t get_channel() const;
   int8_t get_rssi() const;
   bool get_with_auth() const;
@@ -239,7 +313,7 @@ class WiFiScanResult {
   bssid_t bssid_;
   uint8_t channel_;
   int8_t rssi_;
-  std::string ssid_;
+  CompactString ssid_;
   int8_t priority_{0};
   bool matches_{false};
   bool with_auth_;
@@ -363,21 +437,22 @@ class WiFiComponent : public Component {
 
   void retry_connect();
 
-#ifdef USE_RP2040
-  bool can_proceed() override;
-#endif
-
   void set_reboot_timeout(uint32_t reboot_timeout);
 
-  bool is_connected();
+  bool is_connected() const { return this->connected_; }
 
   void set_power_save_mode(WiFiPowerSaveMode power_save);
   void set_min_auth_mode(WifiMinAuthMode min_auth_mode) { min_auth_mode_ = min_auth_mode; }
   void set_output_power(float output_power) { output_power_ = output_power; }
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+  void set_band_mode(wifi_band_mode_t band_mode) { this->band_mode_ = band_mode; }
+#endif
 
   void set_passive_scan(bool passive);
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
+  void save_wifi_sta(const char *ssid, const char *password);
+  void save_wifi_sta(StringRef ssid, StringRef password) { this->save_wifi_sta(ssid.c_str(), password.c_str()); }
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
@@ -388,7 +463,9 @@ class WiFiComponent : public Component {
   void restart_adapter();
   /// WIFI setup_priority.
   float get_setup_priority() const override;
+#ifdef USE_LOOP_PRIORITY
   float get_loop_priority() const override;
+#endif
 
   /// Reconnect WiFi if required.
   void loop() override;
@@ -425,20 +502,11 @@ class WiFiComponent : public Component {
     }
     return 0;
   }
-  void set_sta_priority(const bssid_t bssid, int8_t priority) {
-    for (auto &it : this->sta_priorities_) {
-      if (it.bssid == bssid) {
-        it.priority = priority;
-        return;
-      }
-    }
-    this->sta_priorities_.push_back(WiFiSTAPriority{
-        .bssid = bssid,
-        .priority = priority,
-    });
-  }
+  void set_sta_priority(bssid_t bssid, int8_t priority);
 
   network::IPAddresses wifi_sta_ip_addresses();
+  // Remove before 2026.9.0
+  ESPDEPRECATED("Use wifi_ssid_to() instead. Removed in 2026.9.0", "2026.3.0")
   std::string wifi_ssid();
   /// Write SSID to buffer without heap allocation.
   /// Returns pointer to buffer, or empty string if not connected.
@@ -451,8 +519,12 @@ class WiFiComponent : public Component {
   void set_keep_scan_results(bool keep_scan_results) { this->keep_scan_results_ = keep_scan_results; }
   void set_post_connect_roaming(bool enabled) { this->post_connect_roaming_ = enabled; }
 
-  Trigger<> *get_connect_trigger() const { return this->connect_trigger_; };
-  Trigger<> *get_disconnect_trigger() const { return this->disconnect_trigger_; };
+#ifdef USE_WIFI_CONNECT_TRIGGER
+  Trigger<> *get_connect_trigger() { return &this->connect_trigger_; }
+#endif
+#ifdef USE_WIFI_DISCONNECT_TRIGGER
+  Trigger<> *get_disconnect_trigger() { return &this->disconnect_trigger_; }
+#endif
 
   int32_t get_wifi_channel();
 
@@ -538,7 +610,14 @@ class WiFiComponent : public Component {
   int8_t find_first_non_hidden_index_() const;
   /// Check if an SSID was seen in the most recent scan results
   /// Used to skip hidden mode for SSIDs we know are visible
-  bool ssid_was_seen_in_scan_(const std::string &ssid) const;
+  bool ssid_was_seen_in_scan_(const CompactString &ssid) const;
+  /// Check if full scan results are needed (captive portal active, improv, listeners)
+  bool needs_full_scan_results_() const;
+  /// Check if network matches any configured network (for scan result filtering)
+  /// Matches by SSID when configured, or by BSSID for BSSID-only configs
+  bool matches_configured_network_(const char *ssid, const uint8_t *bssid) const;
+  /// Log a discarded scan result at VERBOSE level (skipped during roaming scans to avoid log overflow)
+  void log_discarded_scan_result_(const char *ssid, const uint8_t *bssid, int8_t rssi, uint8_t channel);
   /// Find next SSID that wasn't in scan results (might be hidden)
   /// Returns index of next potentially hidden SSID, or -1 if none found
   /// @param start_index Start searching from index after this (-1 to start from beginning)
@@ -580,15 +659,23 @@ class WiFiComponent : public Component {
   void connect_soon_();
 
   void wifi_loop_();
+#ifdef USE_ESP8266
+  void process_pending_callbacks_();
+#endif
   bool wifi_mode_(optional<bool> sta, optional<bool> ap);
   bool wifi_sta_pre_setup_();
   bool wifi_apply_output_power_(float output_power);
   bool wifi_apply_power_save_();
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+  bool wifi_apply_band_mode_();
+#endif
   bool wifi_sta_ip_config_(const optional<ManualIP> &manual_ip);
   bool wifi_apply_hostname_();
   bool wifi_sta_connect_(const WiFiAP &ap);
   void wifi_pre_setup_();
-  WiFiSTAConnectStatus wifi_sta_connect_status_();
+  WiFiSTAConnectStatus wifi_sta_connect_status_() const;
+  bool is_connected_() const;
+  void update_connected_state_();
   bool wifi_scan_start_(bool passive);
 
 #ifdef USE_WIFI_AP
@@ -618,6 +705,21 @@ class WiFiComponent : public Component {
   /// Free scan results memory unless a component needs them
   void release_scan_results_();
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  /// Notify connect state listeners (called after state machine reaches STA_CONNECTED)
+  void notify_connect_state_listeners_();
+  /// Notify connect state listeners of disconnection
+  void notify_disconnect_state_listeners_();
+#endif
+#ifdef USE_WIFI_IP_STATE_LISTENERS
+  /// Notify IP state listeners with current addresses
+  void notify_ip_state_listeners_();
+#endif
+#ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
+  /// Notify scan results listeners with current scan results
+  void notify_scan_results_listeners_();
+#endif
+
 #ifdef USE_ESP8266
   static void wifi_event_callback(System_Event_t *event);
   void wifi_scan_done_callback_(void *arg, STATUS status);
@@ -639,13 +741,13 @@ class WiFiComponent : public Component {
   void wifi_scan_done_callback_();
 #endif
 
+  // Large/pointer-aligned members first
   FixedVector<WiFiAP> sta_;
   std::vector<WiFiSTAPriority> sta_priorities_;
   wifi_scan_vector_t<WiFiScanResult> scan_result_;
 #ifdef USE_WIFI_AP
   WiFiAP ap_;
 #endif
-  float output_power_{NAN};
 #ifdef USE_WIFI_IP_STATE_LISTENERS
   StaticVector<WiFiIPStateListener *, ESPHOME_WIFI_IP_STATE_LISTENERS> ip_state_listeners_;
 #endif
@@ -662,6 +764,15 @@ class WiFiComponent : public Component {
 #ifdef USE_WIFI_FAST_CONNECT
   ESPPreferenceObject fast_connect_pref_;
 #endif
+#ifdef USE_WIFI_CONNECT_TRIGGER
+  Trigger<> connect_trigger_;
+#endif
+#ifdef USE_WIFI_DISCONNECT_TRIGGER
+  Trigger<> disconnect_trigger_;
+#endif
+#if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
+  SemaphoreHandle_t high_performance_semaphore_{nullptr};
+#endif
 
   // Post-connect roaming constants
   static constexpr uint32_t ROAMING_CHECK_INTERVAL = 5 * 60 * 1000;  // 5 minutes
@@ -669,7 +780,8 @@ class WiFiComponent : public Component {
   static constexpr int8_t ROAMING_GOOD_RSSI = -49;                   // Skip scan if signal is excellent
   static constexpr uint8_t ROAMING_MAX_ATTEMPTS = 3;
 
-  // Group all 32-bit integers together
+  // 4-byte members
+  float output_power_{NAN};
   uint32_t action_started_;
   uint32_t last_connected_{0};
   uint32_t reboot_timeout_{};
@@ -678,9 +790,12 @@ class WiFiComponent : public Component {
   uint32_t ap_timeout_{};
 #endif
 
-  // Group all 8-bit values together
+  // 1-byte enums and integers
   WiFiComponentState state_{WIFI_COMPONENT_STATE_OFF};
   WiFiPowerSaveMode power_save_{WIFI_POWER_SAVE_NONE};
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+  wifi_band_mode_t band_mode_{WIFI_BAND_MODE_AUTO};
+#endif
   WifiMinAuthMode min_auth_mode_{WIFI_MIN_AUTH_MODE_WPA2};
   WiFiRetryPhase retry_phase_{WiFiRetryPhase::INITIAL_CONNECT};
   uint8_t num_retried_{0};
@@ -689,15 +804,39 @@ class WiFiComponent : public Component {
   // int8_t limits to 127 APs (enforced in __init__.py via MAX_WIFI_NETWORKS)
   int8_t selected_sta_index_{-1};
   uint8_t roaming_attempts_{0};
-
 #if USE_NETWORK_IPV6
   uint8_t num_ipv6_addresses_{0};
 #endif /* USE_NETWORK_IPV6 */
-
-  // Group all boolean values together
-  bool has_ap_{false};
-  bool handled_connected_state_{false};
   bool error_from_callback_{false};
+  RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
+  RoamingState roaming_state_{RoamingState::IDLE};
+#if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
+  WiFiPowerSaveMode configured_power_save_{WIFI_POWER_SAVE_NONE};
+#endif
+
+  // Bools and bitfields
+  // Pending listener callbacks deferred from platform callbacks to main loop.
+  struct {
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+    // Deferred until state machine reaches STA_CONNECTED so wifi.connected
+    // condition returns true in listener automations.
+    bool connect_state : 1;
+#ifdef USE_ESP8266
+    // ESP8266: also defer disconnect notification to main loop
+    bool disconnect : 1;
+#endif
+#endif
+#if defined(USE_ESP8266) && defined(USE_WIFI_IP_STATE_LISTENERS)
+    bool got_ip : 1;
+#endif
+#if defined(USE_ESP8266) && defined(USE_WIFI_SCAN_RESULTS_LISTENERS)
+    bool scan_complete : 1;
+#endif
+  } pending_{};
+  bool has_ap_{false};
+#if defined(USE_WIFI_CONNECT_TRIGGER) || defined(USE_WIFI_DISCONNECT_TRIGGER)
+  bool handled_connected_state_{false};
+#endif
   bool scan_done_{false};
   bool ap_setup_{false};
   bool ap_started_{false};
@@ -710,20 +849,14 @@ class WiFiComponent : public Component {
   bool enable_on_boot_{true};
   bool got_ipv4_address_{false};
   bool keep_scan_results_{false};
-  RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
+  bool has_completed_scan_after_captive_portal_start_{
+      false};  // Tracks if we've completed a scan after captive portal started
   bool skip_cooldown_next_cycle_{false};
+  bool connected_{false};
   bool post_connect_roaming_{true};  // Enabled by default
-  RoamingState roaming_state_{RoamingState::IDLE};
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
-  WiFiPowerSaveMode configured_power_save_{WIFI_POWER_SAVE_NONE};
   bool is_high_performance_mode_{false};
-
-  SemaphoreHandle_t high_performance_semaphore_{nullptr};
 #endif
-
-  // Pointers at the end (naturally aligned)
-  Trigger<> *connect_trigger_{new Trigger<>()};
-  Trigger<> *disconnect_trigger_{new Trigger<>()};
 
  private:
   // Stores a pointer to a string literal (static storage duration).

--- a/components/wifi/wifi_component_esp8266.cpp
+++ b/components/wifi/wifi_component_esp8266.cpp
@@ -6,6 +6,7 @@
 
 #include <user_interface.h>
 
+#include <cassert>
 #include <utility>
 #include <algorithm>
 #ifdef USE_WIFI_WPA2_EAP
@@ -36,6 +37,7 @@ extern "C" {
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include "esphome/core/util.h"
 
 namespace esphome::wifi {
@@ -204,34 +206,28 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   network::IPAddresses addresses;
   uint8_t index = 0;
   for (auto &addr : addrList) {
+    assert(index < addresses.size());
     addresses[index++] = addr.ipFromNetifNum();
   }
   return addresses;
 }
 bool WiFiComponent::wifi_apply_hostname_() {
-  const std::string &hostname = App.get_name();
+  const auto &hostname = App.get_name();
   bool ret = wifi_station_set_hostname(const_cast<char *>(hostname.c_str()));
   if (!ret) {
     ESP_LOGV(TAG, "Set hostname failed");
   }
 
-  // inform dhcp server of hostname change using dhcp_renew()
+  // Update hostname on all lwIP interfaces so DHCP packets include it.
+  // lwIP includes the hostname in DHCP DISCOVER/REQUEST automatically
+  // via LWIP_NETIF_HOSTNAME — no dhcp_renew() needed. The hostname is
+  // fixed at compile time and never changes at runtime.
   for (netif *intf = netif_list; intf; intf = intf->next) {
-    // unconditionally update all known interfaces
 #if LWIP_VERSION_MAJOR == 1
     intf->hostname = (char *) wifi_station_get_hostname();
 #else
     intf->hostname = wifi_station_get_hostname();
 #endif
-    if (netif_dhcp_data(intf) != nullptr) {
-      // renew already started DHCP leases
-      err_t lwipret = dhcp_renew(intf);
-      if (lwipret != ERR_OK) {
-        ESP_LOGW(TAG, "wifi_apply_hostname_(%s): lwIP error %d on interface %c%c (index %d)", intf->hostname,
-                 (int) lwipret, intf->name[0], intf->name[1], intf->num);
-        ret = false;
-      }
-    }
   }
 
   return ret;
@@ -246,16 +242,16 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   struct station_config conf {};
   memset(&conf, 0, sizeof(conf));
-  if (ap.get_ssid().size() > sizeof(conf.ssid)) {
+  if (ap.ssid_.size() > sizeof(conf.ssid)) {
     ESP_LOGE(TAG, "SSID too long");
     return false;
   }
-  if (ap.get_password().size() > sizeof(conf.password)) {
+  if (ap.password_.size() > sizeof(conf.password)) {
     ESP_LOGE(TAG, "Password too long");
     return false;
   }
-  memcpy(reinterpret_cast<char *>(conf.ssid), ap.get_ssid().c_str(), ap.get_ssid().size());
-  memcpy(reinterpret_cast<char *>(conf.password), ap.get_password().c_str(), ap.get_password().size());
+  memcpy(reinterpret_cast<char *>(conf.ssid), ap.ssid_.c_str(), ap.ssid_.size());
+  memcpy(reinterpret_cast<char *>(conf.password), ap.password_.c_str(), ap.password_.size());
 
   if (ap.has_bssid()) {
     conf.bssid_set = 1;
@@ -265,7 +261,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   }
 
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 4, 0)
-  if (ap.get_password().empty()) {
+  if (ap.password_.empty()) {
     conf.threshold.authmode = AUTH_OPEN;
   } else {
     // Set threshold based on configured minimum auth mode
@@ -304,9 +300,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
-  if (ap.get_eap().has_value()) {
+  auto eap_opt = ap.get_eap();
+  if (eap_opt.has_value()) {
     // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
-    EAPAuth eap = ap.get_eap().value();
+    EAPAuth eap = *eap_opt;
     ret = wifi_station_set_enterprise_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
     if (ret) {
       ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_identity failed: %d", ret);
@@ -398,106 +395,82 @@ class WiFiMockClass : public ESP8266WiFiGenericClass {
   static void _event_callback(void *event) { ESP8266WiFiGenericClass::_eventCallback(event); }  // NOLINT
 };
 
+// Auth mode strings indexed by AUTH_* constants (0-4), with UNKNOWN at last index
+// Static asserts verify the SDK constants are contiguous as expected
+static_assert(AUTH_OPEN == 0 && AUTH_WEP == 1 && AUTH_WPA_PSK == 2 && AUTH_WPA2_PSK == 3 && AUTH_WPA_WPA2_PSK == 4,
+              "AUTH_* constants are not contiguous");
+PROGMEM_STRING_TABLE(AuthModeStrings, "OPEN", "WEP", "WPA PSK", "WPA2 PSK", "WPA/WPA2 PSK", "UNKNOWN");
+
 const LogString *get_auth_mode_str(uint8_t mode) {
-  switch (mode) {
-    case AUTH_OPEN:
-      return LOG_STR("OPEN");
-    case AUTH_WEP:
-      return LOG_STR("WEP");
-    case AUTH_WPA_PSK:
-      return LOG_STR("WPA PSK");
-    case AUTH_WPA2_PSK:
-      return LOG_STR("WPA2 PSK");
-    case AUTH_WPA_WPA2_PSK:
-      return LOG_STR("WPA/WPA2 PSK");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
-}
-const LogString *get_op_mode_str(uint8_t mode) {
-  switch (mode) {
-    case WIFI_OFF:
-      return LOG_STR("OFF");
-    case WIFI_STA:
-      return LOG_STR("STA");
-    case WIFI_AP:
-      return LOG_STR("AP");
-    case WIFI_AP_STA:
-      return LOG_STR("AP+STA");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return AuthModeStrings::get_log_str(mode, AuthModeStrings::LAST_INDEX);
 }
 
+// WiFi op mode strings indexed by WIFI_* constants (0-3), with UNKNOWN at last index
+static_assert(WIFI_OFF == 0 && WIFI_STA == 1 && WIFI_AP == 2 && WIFI_AP_STA == 3,
+              "WIFI_* op mode constants are not contiguous");
+PROGMEM_STRING_TABLE(OpModeStrings, "OFF", "STA", "AP", "AP+STA", "UNKNOWN");
+
+const LogString *get_op_mode_str(uint8_t mode) { return OpModeStrings::get_log_str(mode, OpModeStrings::LAST_INDEX); }
+
+// Use if-chain instead of switch to avoid jump tables in RODATA (wastes RAM on ESP8266).
+// A single switch would generate a sparse lookup table with ~175 default entries, wasting 700 bytes of RAM.
+// Even split switches still generate smaller jump tables in RODATA.
 const LogString *get_disconnect_reason_str(uint8_t reason) {
-  /* If this were one big switch statement, GCC would generate a lookup table for it. However, the values of the
-   * REASON_* constants aren't continuous, and GCC will fill in the gap with the default value -- wasting 4 bytes of RAM
-   * per entry. As there's ~175 default entries, this wastes 700 bytes of RAM.
-   */
-  if (reason <= REASON_CIPHER_SUITE_REJECTED) {  // This must be the last constant with a value <200
-    switch (reason) {
-      case REASON_AUTH_EXPIRE:
-        return LOG_STR("Auth Expired");
-      case REASON_AUTH_LEAVE:
-        return LOG_STR("Auth Leave");
-      case REASON_ASSOC_EXPIRE:
-        return LOG_STR("Association Expired");
-      case REASON_ASSOC_TOOMANY:
-        return LOG_STR("Too Many Associations");
-      case REASON_NOT_AUTHED:
-        return LOG_STR("Not Authenticated");
-      case REASON_NOT_ASSOCED:
-        return LOG_STR("Not Associated");
-      case REASON_ASSOC_LEAVE:
-        return LOG_STR("Association Leave");
-      case REASON_ASSOC_NOT_AUTHED:
-        return LOG_STR("Association not Authenticated");
-      case REASON_DISASSOC_PWRCAP_BAD:
-        return LOG_STR("Disassociate Power Cap Bad");
-      case REASON_DISASSOC_SUPCHAN_BAD:
-        return LOG_STR("Disassociate Supported Channel Bad");
-      case REASON_IE_INVALID:
-        return LOG_STR("IE Invalid");
-      case REASON_MIC_FAILURE:
-        return LOG_STR("Mic Failure");
-      case REASON_4WAY_HANDSHAKE_TIMEOUT:
-        return LOG_STR("4-Way Handshake Timeout");
-      case REASON_GROUP_KEY_UPDATE_TIMEOUT:
-        return LOG_STR("Group Key Update Timeout");
-      case REASON_IE_IN_4WAY_DIFFERS:
-        return LOG_STR("IE In 4-Way Handshake Differs");
-      case REASON_GROUP_CIPHER_INVALID:
-        return LOG_STR("Group Cipher Invalid");
-      case REASON_PAIRWISE_CIPHER_INVALID:
-        return LOG_STR("Pairwise Cipher Invalid");
-      case REASON_AKMP_INVALID:
-        return LOG_STR("AKMP Invalid");
-      case REASON_UNSUPP_RSN_IE_VERSION:
-        return LOG_STR("Unsupported RSN IE version");
-      case REASON_INVALID_RSN_IE_CAP:
-        return LOG_STR("Invalid RSN IE Cap");
-      case REASON_802_1X_AUTH_FAILED:
-        return LOG_STR("802.1x Authentication Failed");
-      case REASON_CIPHER_SUITE_REJECTED:
-        return LOG_STR("Cipher Suite Rejected");
-    }
-  }
-
-  switch (reason) {
-    case REASON_BEACON_TIMEOUT:
-      return LOG_STR("Beacon Timeout");
-    case REASON_NO_AP_FOUND:
-      return LOG_STR("AP Not Found");
-    case REASON_AUTH_FAIL:
-      return LOG_STR("Authentication Failed");
-    case REASON_ASSOC_FAIL:
-      return LOG_STR("Association Failed");
-    case REASON_HANDSHAKE_TIMEOUT:
-      return LOG_STR("Handshake Failed");
-    case REASON_UNSPECIFIED:
-    default:
-      return LOG_STR("Unspecified");
-  }
+  if (reason == REASON_AUTH_EXPIRE)
+    return LOG_STR("Auth Expired");
+  if (reason == REASON_AUTH_LEAVE)
+    return LOG_STR("Auth Leave");
+  if (reason == REASON_ASSOC_EXPIRE)
+    return LOG_STR("Association Expired");
+  if (reason == REASON_ASSOC_TOOMANY)
+    return LOG_STR("Too Many Associations");
+  if (reason == REASON_NOT_AUTHED)
+    return LOG_STR("Not Authenticated");
+  if (reason == REASON_NOT_ASSOCED)
+    return LOG_STR("Not Associated");
+  if (reason == REASON_ASSOC_LEAVE)
+    return LOG_STR("Association Leave");
+  if (reason == REASON_ASSOC_NOT_AUTHED)
+    return LOG_STR("Association not Authenticated");
+  if (reason == REASON_DISASSOC_PWRCAP_BAD)
+    return LOG_STR("Disassociate Power Cap Bad");
+  if (reason == REASON_DISASSOC_SUPCHAN_BAD)
+    return LOG_STR("Disassociate Supported Channel Bad");
+  if (reason == REASON_IE_INVALID)
+    return LOG_STR("IE Invalid");
+  if (reason == REASON_MIC_FAILURE)
+    return LOG_STR("Mic Failure");
+  if (reason == REASON_4WAY_HANDSHAKE_TIMEOUT)
+    return LOG_STR("4-Way Handshake Timeout");
+  if (reason == REASON_GROUP_KEY_UPDATE_TIMEOUT)
+    return LOG_STR("Group Key Update Timeout");
+  if (reason == REASON_IE_IN_4WAY_DIFFERS)
+    return LOG_STR("IE In 4-Way Handshake Differs");
+  if (reason == REASON_GROUP_CIPHER_INVALID)
+    return LOG_STR("Group Cipher Invalid");
+  if (reason == REASON_PAIRWISE_CIPHER_INVALID)
+    return LOG_STR("Pairwise Cipher Invalid");
+  if (reason == REASON_AKMP_INVALID)
+    return LOG_STR("AKMP Invalid");
+  if (reason == REASON_UNSUPP_RSN_IE_VERSION)
+    return LOG_STR("Unsupported RSN IE version");
+  if (reason == REASON_INVALID_RSN_IE_CAP)
+    return LOG_STR("Invalid RSN IE Cap");
+  if (reason == REASON_802_1X_AUTH_FAILED)
+    return LOG_STR("802.1x Authentication Failed");
+  if (reason == REASON_CIPHER_SUITE_REJECTED)
+    return LOG_STR("Cipher Suite Rejected");
+  if (reason == REASON_BEACON_TIMEOUT)
+    return LOG_STR("Beacon Timeout");
+  if (reason == REASON_NO_AP_FOUND)
+    return LOG_STR("AP Not Found");
+  if (reason == REASON_AUTH_FAIL)
+    return LOG_STR("Authentication Failed");
+  if (reason == REASON_ASSOC_FAIL)
+    return LOG_STR("Association Failed");
+  if (reason == REASON_HANDSHAKE_TIMEOUT)
+    return LOG_STR("Handshake Failed");
+  return LOG_STR("Unspecified");
 }
 
 void WiFiComponent::wifi_event_callback(System_Event_t *event) {
@@ -512,19 +485,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
 #endif
       s_sta_connected = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-      for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
-      }
-#endif
-      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
-#if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
-      if (const WiFiAP *config = global_wifi_component->get_selected_sta_();
-          config && config->get_manual_ip().has_value()) {
-        for (auto *listener : global_wifi_component->ip_state_listeners_) {
-          listener->on_ip_state(global_wifi_component->wifi_sta_ip_addresses(),
-                                global_wifi_component->get_dns_address(0), global_wifi_component->get_dns_address(1));
-        }
-      }
+      // Defer listener notification until state machine reaches STA_CONNECTED
+      // This ensures wifi.connected condition returns true in listener automations
+      global_wifi_component->pending_.connect_state = true;
 #endif
       break;
     }
@@ -543,16 +506,9 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       }
       s_sta_connected = false;
       s_sta_connecting = false;
-      // IMPORTANT: Set error flag BEFORE notifying listeners.
-      // This ensures is_connected() returns false during listener callbacks,
-      // which is critical for proper reconnection logic (e.g., roaming).
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-      // Notify listeners AFTER setting error flag so they see correct state
-      static constexpr uint8_t EMPTY_BSSID[6] = {};
-      for (auto *listener : global_wifi_component->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
-      }
+      global_wifi_component->pending_.disconnect = true;
 #endif
       break;
     }
@@ -564,8 +520,6 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       // https://lbsfilm.at/blog/wpa2-authenticationmode-downgrade-in-espressif-microprocessors
       if (it.old_mode != AUTH_OPEN && it.new_mode == AUTH_OPEN) {
         ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting");
-        // we can't call retry_connect() from this context, so disconnect immediately
-        // and notify main thread with error_from_callback_
         wifi_station_disconnect();
         global_wifi_component->error_from_callback_ = true;
       }
@@ -579,10 +533,8 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
                network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
       s_sta_got_ip = true;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-      for (auto *listener : global_wifi_component->ip_state_listeners_) {
-        listener->on_ip_state(global_wifi_component->wifi_sta_ip_addresses(), global_wifi_component->get_dns_address(0),
-                              global_wifi_component->get_dns_address(1));
-      }
+      // Defer listener callbacks to main loop - system context has limited stack
+      global_wifi_component->pending_.got_ip = true;
 #endif
       break;
     }
@@ -673,30 +625,26 @@ void WiFiComponent::wifi_pre_setup_() {
   this->wifi_mode_(false, false);
 }
 
-WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
+WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   station_status_t status = wifi_station_get_connect_status();
-  switch (status) {
-    case STATION_GOT_IP:
-      return WiFiSTAConnectStatus::CONNECTED;
-    case STATION_NO_AP_FOUND:
-      return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
-      ;
-    case STATION_CONNECT_FAIL:
-    case STATION_WRONG_PASSWORD:
-      return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
-    case STATION_CONNECTING:
-      return WiFiSTAConnectStatus::CONNECTING;
-    case STATION_IDLE:
-    default:
-      return WiFiSTAConnectStatus::IDLE;
-  }
+  if (status == STATION_GOT_IP)
+    return WiFiSTAConnectStatus::CONNECTED;
+  if (status == STATION_NO_AP_FOUND)
+    return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
+  if (status == STATION_CONNECT_FAIL || status == STATION_WRONG_PASSWORD)
+    return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
+  if (status == STATION_CONNECTING)
+    return WiFiSTAConnectStatus::CONNECTING;
+  return WiFiSTAConnectStatus::IDLE;
 }
 bool WiFiComponent::wifi_scan_start_(bool passive) {
-  static bool first_scan = false;
-
   // enable STA
   if (!this->wifi_mode_(true, {}))
     return false;
+
+  // Reset scan_done_ before starting new scan to prevent stale flag from previous scan
+  // (e.g., roaming scan completed just before unexpected disconnect)
+  this->scan_done_ = false;
 
   struct scan_config config {};
   memset(&config, 0, sizeof(config));
@@ -706,23 +654,13 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   config.show_hidden = 1;
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 4, 0)
   config.scan_type = passive ? WIFI_SCAN_TYPE_PASSIVE : WIFI_SCAN_TYPE_ACTIVE;
-  if (first_scan) {
-    if (passive) {
-      config.scan_time.passive = 200;
-    } else {
-      config.scan_time.active.min = 100;
-      config.scan_time.active.max = 200;
-    }
+  if (passive) {
+    config.scan_time.passive = 500;
   } else {
-    if (passive) {
-      config.scan_time.passive = 500;
-    } else {
-      config.scan_time.active.min = 400;
-      config.scan_time.active.max = 500;
-    }
+    config.scan_time.active.min = 400;
+    config.scan_time.active.max = 500;
   }
 #endif
-  first_scan = false;
   bool ret = wifi_station_scan(&config, &WiFiComponent::s_wifi_scan_done_callback);
   if (!ret) {
     ESP_LOGV(TAG, "wifi_station_scan failed");
@@ -752,29 +690,45 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
 
   if (status != OK) {
     ESP_LOGV(TAG, "Scan failed: %d", status);
-    this->retry_connect();
+    // Don't call retry_connect() here - this callback runs in SDK system context
+    // where yield() cannot be called. Instead, just set scan_done_ and let
+    // check_scanning_finished() handle the empty scan_result_ from loop context.
+    this->scan_done_ = true;
     return;
   }
 
-  // Count the number of results first
   auto *head = reinterpret_cast<bss_info *>(arg);
+  bool needs_full = this->needs_full_scan_results_();
+
+  // First pass: count matching networks (linked list is non-destructive)
+  size_t total = 0;
   size_t count = 0;
   for (bss_info *it = head; it != nullptr; it = STAILQ_NEXT(it, next)) {
-    count++;
+    total++;
+    const char *ssid_cstr = reinterpret_cast<const char *>(it->ssid);
+    if (needs_full || this->matches_configured_network_(ssid_cstr, it->bssid)) {
+      count++;
+    }
   }
 
-  this->scan_result_.init(count);
+  this->scan_result_.init(count);  // Exact allocation
+
+  // Second pass: store matching networks
   for (bss_info *it = head; it != nullptr; it = STAILQ_NEXT(it, next)) {
-    this->scan_result_.emplace_back(
-        bssid_t{it->bssid[0], it->bssid[1], it->bssid[2], it->bssid[3], it->bssid[4], it->bssid[5]},
-        std::string(reinterpret_cast<char *>(it->ssid), it->ssid_len), it->channel, it->rssi, it->authmode != AUTH_OPEN,
-        it->is_hidden != 0);
+    const char *ssid_cstr = reinterpret_cast<const char *>(it->ssid);
+    if (needs_full || this->matches_configured_network_(ssid_cstr, it->bssid)) {
+      this->scan_result_.emplace_back(
+          bssid_t{it->bssid[0], it->bssid[1], it->bssid[2], it->bssid[3], it->bssid[4], it->bssid[5]}, ssid_cstr,
+          it->ssid_len, it->channel, it->rssi, it->authmode != AUTH_OPEN, it->is_hidden != 0);
+    } else {
+      this->log_discarded_scan_result_(ssid_cstr, it->bssid, it->rssi, it->channel);
+    }
   }
+  ESP_LOGV(TAG, "Scan complete: %zu found, %zu stored%s", total, this->scan_result_.size(),
+           needs_full ? "" : " (filtered)");
   this->scan_done_ = true;
 #ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
-  for (auto *listener : global_wifi_component->scan_results_listeners_) {
-    listener->on_wifi_scan_results(global_wifi_component->scan_result_);
-  }
+  this->pending_.scan_complete = true;  // Defer listener callbacks to main loop
 #endif
 }
 
@@ -858,27 +812,27 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
     return false;
 
   struct softap_config conf {};
-  if (ap.get_ssid().size() > sizeof(conf.ssid)) {
+  if (ap.ssid_.size() > sizeof(conf.ssid)) {
     ESP_LOGE(TAG, "AP SSID too long");
     return false;
   }
-  memcpy(reinterpret_cast<char *>(conf.ssid), ap.get_ssid().c_str(), ap.get_ssid().size());
-  conf.ssid_len = static_cast<uint8>(ap.get_ssid().size());
+  memcpy(reinterpret_cast<char *>(conf.ssid), ap.ssid_.c_str(), ap.ssid_.size());
+  conf.ssid_len = static_cast<uint8>(ap.ssid_.size());
   conf.channel = ap.has_channel() ? ap.get_channel() : 1;
   conf.ssid_hidden = ap.get_hidden();
   conf.max_connection = 5;
   conf.beacon_interval = 100;
 
-  if (ap.get_password().empty()) {
+  if (ap.password_.empty()) {
     conf.authmode = AUTH_OPEN;
     *conf.password = 0;
   } else {
     conf.authmode = AUTH_WPA2_PSK;
-    if (ap.get_password().size() > sizeof(conf.password)) {
+    if (ap.password_.size() > sizeof(conf.password)) {
       ESP_LOGE(TAG, "AP password too long");
       return false;
     }
-    memcpy(reinterpret_cast<char *>(conf.password), ap.get_password().c_str(), ap.get_password().size());
+    memcpy(reinterpret_cast<char *>(conf.password), ap.password_.c_str(), ap.password_.size());
   }
 
   ETS_UART_INTR_DISABLE();
@@ -961,7 +915,34 @@ network::IPAddress WiFiComponent::wifi_gateway_ip_() {
   return network::IPAddress(&ip.gw);
 }
 network::IPAddress WiFiComponent::wifi_dns_ip_(int num) { return network::IPAddress(dns_getserver(num)); }
-void WiFiComponent::wifi_loop_() {}
+void WiFiComponent::wifi_loop_() { this->process_pending_callbacks_(); }
+
+void WiFiComponent::process_pending_callbacks_() {
+  // Process callbacks deferred from ESP8266 SDK system context (~2KB stack)
+  // to main loop context (full stack). Connect state listeners are handled
+  // by notify_connect_state_listeners_() in the shared state machine code.
+
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  if (this->pending_.disconnect) {
+    this->pending_.disconnect = false;
+    this->notify_disconnect_state_listeners_();
+  }
+#endif
+
+#ifdef USE_WIFI_IP_STATE_LISTENERS
+  if (this->pending_.got_ip) {
+    this->pending_.got_ip = false;
+    this->notify_ip_state_listeners_();
+  }
+#endif
+
+#ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
+  if (this->pending_.scan_complete) {
+    this->pending_.scan_complete = false;
+    this->notify_scan_results_listeners_();
+  }
+#endif
+}
 
 }  // namespace esphome::wifi
 #endif

--- a/components/wifi/wifi_component_esp_idf.cpp
+++ b/components/wifi/wifi_component_esp_idf.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <memory>
 #include <utility>
 #ifdef USE_WIFI_WPA2_EAP
 #if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
@@ -291,6 +292,10 @@ bool WiFiComponent::wifi_apply_power_save_() {
   return success;
 }
 
+#ifdef SOC_WIFI_SUPPORT_5G
+bool WiFiComponent::wifi_apply_band_mode_() { return esp_wifi_set_band_mode(this->band_mode_) == ESP_OK; }
+#endif
+
 bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   // enable STA
   if (!this->wifi_mode_(true, {}))
@@ -299,19 +304,19 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv417wifi_sta_config_t
   wifi_config_t conf;
   memset(&conf, 0, sizeof(conf));
-  if (ap.get_ssid().size() > sizeof(conf.sta.ssid)) {
+  if (ap.ssid_.size() > sizeof(conf.sta.ssid)) {
     ESP_LOGE(TAG, "SSID too long");
     return false;
   }
-  if (ap.get_password().size() > sizeof(conf.sta.password)) {
+  if (ap.password_.size() > sizeof(conf.sta.password)) {
     ESP_LOGE(TAG, "Password too long");
     return false;
   }
-  memcpy(reinterpret_cast<char *>(conf.sta.ssid), ap.get_ssid().c_str(), ap.get_ssid().size());
-  memcpy(reinterpret_cast<char *>(conf.sta.password), ap.get_password().c_str(), ap.get_password().size());
+  memcpy(reinterpret_cast<char *>(conf.sta.ssid), ap.ssid_.c_str(), ap.ssid_.size());
+  memcpy(reinterpret_cast<char *>(conf.sta.password), ap.password_.c_str(), ap.password_.size());
 
   // The weakest authmode to accept in the fast scan mode
-  if (ap.get_password().empty()) {
+  if (ap.password_.empty()) {
     conf.sta.threshold.authmode = WIFI_AUTH_OPEN;
   } else {
     // Set threshold based on configured minimum auth mode
@@ -398,9 +403,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
-  if (ap.get_eap().has_value()) {
+  auto eap_opt = ap.get_eap();
+  if (eap_opt.has_value()) {
     // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
-    EAPAuth eap = ap.get_eap().value();
+    EAPAuth eap = *eap_opt;
 #if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
     err = esp_eap_client_set_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
 #else
@@ -579,6 +585,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   uint8_t count = 0;
   count = esp_netif_get_all_ip6(s_sta_netif, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
+  assert(count < addresses.size());
   for (int i = 0; i < count; i++) {
     addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
   }
@@ -709,6 +716,9 @@ void WiFiComponent::wifi_loop_() {
     delete data;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }
+// Events are processed from queue in main loop context, but listener notifications
+// must be deferred until after the state machine transitions (in check_connecting_finished)
+// so that conditions like wifi.connected return correct values in automations.
 void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   esp_err_t err;
   if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_START) {
@@ -722,6 +732,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_started = true;
     // re-apply power save mode
     wifi_apply_power_save_();
+#ifdef SOC_WIFI_SUPPORT_5G
+    wifi_apply_band_mode_();
+#endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_STA_STOP) {
     ESP_LOGV(TAG, "STA stop");
@@ -742,16 +755,14 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 #endif
     s_sta_connected = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-    for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
-    }
+    // Defer listener notification until state machine reaches STA_CONNECTED
+    // This ensures wifi.connected condition returns true in listener automations
+    this->pending_.connect_state = true;
 #endif
     // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
 #if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
     if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
-      for (auto *listener : this->ip_state_listeners_) {
-        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-      }
+      this->notify_ip_state_listeners_();
     }
 #endif
 
@@ -775,10 +786,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connecting = false;
     error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-    static constexpr uint8_t EMPTY_BSSID[6] = {};
-    for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
-    }
+    this->notify_disconnect_state_listeners_();
 #endif
 
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_GOT_IP) {
@@ -789,9 +797,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     ESP_LOGV(TAG, "static_ip=" IPSTR " gateway=" IPSTR, IP2STR(&it.ip_info.ip), IP2STR(&it.ip_info.gw));
     this->got_ipv4_address_ = true;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-    for (auto *listener : this->ip_state_listeners_) {
-      listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-    }
+    this->notify_ip_state_listeners_();
 #endif
 
 #if USE_NETWORK_IPV6
@@ -800,9 +806,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     ESP_LOGV(TAG, "IPv6 address=" IPV6STR, IPV62STR(it.ip6_info.ip));
     this->num_ipv6_addresses_++;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-    for (auto *listener : this->ip_state_listeners_) {
-      listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-    }
+    this->notify_ip_state_listeners_();
 #endif
 #endif /* USE_NETWORK_IPV6 */
 
@@ -827,27 +831,58 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     }
 
     uint16_t number = it.number;
-    scan_result_.init(number);
+    bool needs_full = this->needs_full_scan_results_();
 
-    // Process one record at a time to avoid large buffer allocation
-    wifi_ap_record_t record;
+    // Smart reserve: full capacity if needed, small reserve otherwise
+    if (needs_full) {
+      this->scan_result_.reserve(number);
+    } else {
+      this->scan_result_.reserve(WIFI_SCAN_RESULT_FILTERED_RESERVE);
+    }
+
+#ifdef USE_ESP32_HOSTED
+    // getting records one at a time fails on P4 with hosted esp32 WiFi coprocessor
+    // Presumably an upstream bug, work-around by getting all records at once
+    // Use stack buffer (3904 bytes / ~80 bytes per record = ~48 records) with heap fallback
+    static constexpr size_t SCAN_RECORD_STACK_COUNT = 3904 / sizeof(wifi_ap_record_t);
+    SmallBufferWithHeapFallback<SCAN_RECORD_STACK_COUNT, wifi_ap_record_t> records(number);
+    err = esp_wifi_scan_get_ap_records(&number, records.get());
+    if (err != ESP_OK) {
+      esp_wifi_clear_ap_list();
+      ESP_LOGW(TAG, "esp_wifi_scan_get_ap_records failed: %s", esp_err_to_name(err));
+      return;
+    }
     for (uint16_t i = 0; i < number; i++) {
+      wifi_ap_record_t &record = records.get()[i];
+#else
+    // Process one record at a time to avoid large buffer allocation
+    for (uint16_t i = 0; i < number; i++) {
+      wifi_ap_record_t record;
       err = esp_wifi_scan_get_ap_record(&record);
       if (err != ESP_OK) {
         ESP_LOGW(TAG, "esp_wifi_scan_get_ap_record failed: %s", esp_err_to_name(err));
         esp_wifi_clear_ap_list();  // Free remaining records not yet retrieved
         break;
       }
-      bssid_t bssid;
-      std::copy(record.bssid, record.bssid + 6, bssid.begin());
-      std::string ssid(reinterpret_cast<const char *>(record.ssid));
-      scan_result_.emplace_back(bssid, ssid, record.primary, record.rssi, record.authmode != WIFI_AUTH_OPEN,
-                                ssid.empty());
+#endif  // USE_ESP32_HOSTED
+
+      // Check C string first - avoid std::string construction for non-matching networks
+      const char *ssid_cstr = reinterpret_cast<const char *>(record.ssid);
+
+      // Only construct std::string and store if needed
+      if (needs_full || this->matches_configured_network_(ssid_cstr, record.bssid)) {
+        bssid_t bssid;
+        std::copy(record.bssid, record.bssid + 6, bssid.begin());
+        this->scan_result_.emplace_back(bssid, ssid_cstr, strlen(ssid_cstr), record.primary, record.rssi,
+                                        record.authmode != WIFI_AUTH_OPEN, ssid_cstr[0] == '\0');
+      } else {
+        this->log_discarded_scan_result_(ssid_cstr, record.bssid, record.rssi, record.primary);
+      }
     }
+    ESP_LOGV(TAG, "Scan complete: %u found, %zu stored%s", number, this->scan_result_.size(),
+             needs_full ? "" : " (filtered)");
 #ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
-    for (auto *listener : this->scan_results_listeners_) {
-      listener->on_wifi_scan_results(this->scan_result_);
-    }
+    this->notify_scan_results_listeners_();
 #endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_AP_START) {
@@ -888,7 +923,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
   }
 }
 
-WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
+WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   if (s_sta_connected && this->got_ipv4_address_) {
 #if USE_NETWORK_IPV6 && (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
     if (this->num_ipv6_addresses_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT) {
@@ -1028,26 +1063,26 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   wifi_config_t conf;
   memset(&conf, 0, sizeof(conf));
-  if (ap.get_ssid().size() > sizeof(conf.ap.ssid)) {
+  if (ap.ssid_.size() > sizeof(conf.ap.ssid)) {
     ESP_LOGE(TAG, "AP SSID too long");
     return false;
   }
-  memcpy(reinterpret_cast<char *>(conf.ap.ssid), ap.get_ssid().c_str(), ap.get_ssid().size());
+  memcpy(reinterpret_cast<char *>(conf.ap.ssid), ap.ssid_.c_str(), ap.ssid_.size());
   conf.ap.channel = ap.has_channel() ? ap.get_channel() : 1;
-  conf.ap.ssid_hidden = ap.get_ssid().size();
+  conf.ap.ssid_hidden = ap.get_hidden();
   conf.ap.max_connection = 5;
   conf.ap.beacon_interval = 100;
 
-  if (ap.get_password().empty()) {
+  if (ap.password_.empty()) {
     conf.ap.authmode = WIFI_AUTH_OPEN;
     *conf.ap.password = 0;
   } else {
     conf.ap.authmode = WIFI_AUTH_WPA2_PSK;
-    if (ap.get_password().size() > sizeof(conf.ap.password)) {
+    if (ap.password_.size() > sizeof(conf.ap.password)) {
       ESP_LOGE(TAG, "AP password too long");
       return false;
     }
-    memcpy(reinterpret_cast<char *>(conf.ap.password), ap.get_password().c_str(), ap.get_password().size());
+    memcpy(reinterpret_cast<char *>(conf.ap.password), ap.password_.c_str(), ap.password_.size());
   }
 
   // pairwise cipher of SoftAP, group cipher will be derived using this.

--- a/components/wifi/wifi_component_libretiny.cpp
+++ b/components/wifi/wifi_component_libretiny.cpp
@@ -13,6 +13,19 @@
 #include <FreeRTOS.h>
 #include <queue.h>
 
+#ifdef USE_BK72XX
+extern "C" {
+#include <wlan_ui_pub.h>
+}
+#endif
+
+#ifdef USE_RTL87XX
+extern "C" {
+#include <wifi_conf.h>
+#include <wifi_structures.h>
+}
+#endif
+
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -193,7 +206,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
 
   String ssid = WiFi.SSID();
-  if (ssid && strcmp(ssid.c_str(), ap.get_ssid().c_str()) != 0) {
+  if (ssid && strcmp(ssid.c_str(), ap.ssid_.c_str()) != 0) {
     WiFi.disconnect();
   }
 
@@ -213,7 +226,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   s_sta_state = LTWiFiSTAState::CONNECTING;
   s_ignored_disconnect_count = 0;
 
-  WiFiStatus status = WiFi.begin(ap.get_ssid().c_str(), ap.get_password().empty() ? NULL : ap.get_password().c_str(),
+  WiFiStatus status = WiFi.begin(ap.ssid_.c_str(), ap.password_.empty() ? NULL : ap.password_.c_str(),
                                  ap.get_channel(),  // 0 = auto
                                  ap.has_bssid() ? ap.get_bssid().data() : NULL);
   if (status != WL_CONNECTED) {
@@ -423,7 +436,10 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
   }
 }
 
-// Process a single event from the queue - runs in main loop context
+// Process a single event from the queue - runs in main loop context.
+// Listener notifications must be deferred until after the state machine transitions
+// (in check_connecting_finished) so that conditions like wifi.connected return
+// correct values in automations.
 void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
   switch (event->event_id) {
     case ESPHOME_EVENT_ID_WIFI_READY: {
@@ -456,17 +472,17 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       // This matches ESP32 IDF behavior where s_sta_connected is set but
       // wifi_sta_connect_status_() also checks got_ipv4_address_
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-      for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(it.ssid, it.ssid_len), it.bssid);
-      }
+      // Defer listener notification until state machine reaches STA_CONNECTED
+      // This ensures wifi.connected condition returns true in listener automations
+      this->pending_.connect_state = true;
 #endif
-      // For static IP configurations, GOT_IP event may not fire, so notify IP listeners here
-#if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
+      // For static IP configurations, GOT_IP event may not fire, so set connected state here
+#ifdef USE_WIFI_MANUAL_IP
       if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
         s_sta_state = LTWiFiSTAState::CONNECTED;
-        for (auto *listener : this->ip_state_listeners_) {
-          listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-        }
+#ifdef USE_WIFI_IP_STATE_LISTENERS
+        this->notify_ip_state_listeners_();
+#endif
       }
 #endif
       break;
@@ -522,10 +538,7 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       }
 
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-      static constexpr uint8_t EMPTY_BSSID[6] = {};
-      for (auto *listener : this->connect_state_listeners_) {
-        listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
-      }
+      this->notify_disconnect_state_listeners_();
 #endif
       break;
     }
@@ -548,18 +561,14 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
                network::IPAddress(WiFi.gatewayIP()).str_to(gw_buf));
       s_sta_state = LTWiFiSTAState::CONNECTED;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-      for (auto *listener : this->ip_state_listeners_) {
-        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-      }
+      this->notify_ip_state_listeners_();
 #endif
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_GOT_IP6: {
       ESP_LOGV(TAG, "Got IPv6");
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-      for (auto *listener : this->ip_state_listeners_) {
-        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-      }
+      this->notify_ip_state_listeners_();
 #endif
       break;
     }
@@ -625,7 +634,7 @@ void WiFiComponent::wifi_pre_setup_() {
   // Make sure WiFi is in clean state before anything starts
   this->wifi_mode_(false, false);
 }
-WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
+WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // Use state machine instead of querying WiFi.status() directly
   // State is updated in main loop from queued events, ensuring thread safety
   switch (s_sta_state) {
@@ -647,6 +656,10 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   if (!this->wifi_mode_(true, {}))
     return false;
 
+  // Reset scan_done_ before starting new scan to prevent stale flag from previous scan
+  // (e.g., roaming scan completed just before unexpected disconnect)
+  this->scan_done_ = false;
+
   // need to use WiFi because of WiFiScanClass allocations :(
   int16_t err = WiFi.scanNetworks(true, true, passive, 200);
   if (err != WIFI_SCAN_RUNNING) {
@@ -664,23 +677,42 @@ void WiFiComponent::wifi_scan_done_callback_() {
   if (num < 0)
     return;
 
-  this->scan_result_.init(static_cast<unsigned int>(num));
-  for (int i = 0; i < num; i++) {
-    String ssid = WiFi.SSID(i);
-    wifi_auth_mode_t authmode = WiFi.encryptionType(i);
-    int32_t rssi = WiFi.RSSI(i);
-    uint8_t *bssid = WiFi.BSSID(i);
-    int32_t channel = WiFi.channel(i);
+  bool needs_full = this->needs_full_scan_results_();
 
-    this->scan_result_.emplace_back(bssid_t{bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]},
-                                    std::string(ssid.c_str()), channel, rssi, authmode != WIFI_AUTH_OPEN,
-                                    ssid.length() == 0);
+  // Access scan results directly via WiFi.scan struct to avoid Arduino String allocations
+  // WiFi.scan is public in LibreTiny for WiFiEvents & WiFiScan static handlers
+  auto *scan = WiFi.scan;
+
+  // First pass: count matching networks
+  size_t count = 0;
+  for (int i = 0; i < num; i++) {
+    const char *ssid_cstr = scan->ap[i].ssid;
+    if (needs_full || this->matches_configured_network_(ssid_cstr, scan->ap[i].bssid.addr)) {
+      count++;
+    }
   }
+
+  this->scan_result_.init(count);  // Exact allocation
+
+  // Second pass: store matching networks
+  for (int i = 0; i < num; i++) {
+    const char *ssid_cstr = scan->ap[i].ssid;
+    if (needs_full || this->matches_configured_network_(ssid_cstr, scan->ap[i].bssid.addr)) {
+      auto &ap = scan->ap[i];
+      this->scan_result_.emplace_back(bssid_t{ap.bssid.addr[0], ap.bssid.addr[1], ap.bssid.addr[2], ap.bssid.addr[3],
+                                              ap.bssid.addr[4], ap.bssid.addr[5]},
+                                      ssid_cstr, strlen(ssid_cstr), ap.channel, ap.rssi, ap.auth != WIFI_AUTH_OPEN,
+                                      ssid_cstr[0] == '\0');
+    } else {
+      auto &ap = scan->ap[i];
+      this->log_discarded_scan_result_(ssid_cstr, ap.bssid.addr, ap.rssi, ap.channel);
+    }
+  }
+  ESP_LOGV(TAG, "Scan complete: %d found, %zu stored%s", num, this->scan_result_.size(),
+           needs_full ? "" : " (filtered)");
   WiFi.scanDelete();
 #ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
-  for (auto *listener : this->scan_results_listeners_) {
-    listener->on_wifi_scan_results(this->scan_result_);
-  }
+  this->notify_scan_results_listeners_();
 #endif
 }
 
@@ -716,7 +748,7 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
 
   yield();
 
-  return WiFi.softAP(ap.get_ssid().c_str(), ap.get_password().empty() ? NULL : ap.get_password().c_str(),
+  return WiFi.softAP(ap.ssid_.c_str(), ap.password_.empty() ? NULL : ap.password_.c_str(),
                      ap.has_channel() ? ap.get_channel() : 1, ap.get_hidden());
 }
 
@@ -741,10 +773,22 @@ bssid_t WiFiComponent::wifi_bssid() {
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
 const char *WiFiComponent::wifi_ssid_to(std::span<char, SSID_BUFFER_SIZE> buffer) {
-  // TODO: Find direct LibreTiny API to avoid Arduino String allocation
+#ifdef USE_BK72XX
+  LinkStatusTypeDef link_status{};
+  bk_wlan_get_link_status(&link_status);
+  size_t len = strnlen(reinterpret_cast<const char *>(link_status.ssid), SSID_BUFFER_SIZE - 1);
+  memcpy(buffer.data(), link_status.ssid, len);
+#elif defined(USE_RTL87XX)
+  rtw_wifi_setting_t setting{};
+  wifi_get_setting("wlan0", &setting);
+  size_t len = strnlen(reinterpret_cast<const char *>(setting.ssid), SSID_BUFFER_SIZE - 1);
+  memcpy(buffer.data(), setting.ssid, len);
+#else
+  // LN882X: wifi_get_sta_conn_info() provides direct pointer access
   String ssid = WiFi.SSID();
   size_t len = std::min(static_cast<size_t>(ssid.length()), SSID_BUFFER_SIZE - 1);
   memcpy(buffer.data(), ssid.c_str(), len);
+#endif
   buffer[len] = '\0';
   return buffer.data();
 }

--- a/components/wifi/wifi_component_pico_w.cpp
+++ b/components/wifi/wifi_component_pico_w.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_WIFI
 #ifdef USE_RP2040
 
+#include <cassert>
+
 #include "lwip/dns.h"
 #include "lwip/err.h"
 #include "lwip/netif.h"
@@ -18,25 +20,49 @@ namespace esphome::wifi {
 
 static const char *const TAG = "wifi_pico_w";
 
+// Check if STA is fully connected (WiFi joined + has IP address).
+// Do NOT use WiFi.status() or WiFi.connected() for this — in AP-only mode they
+// unconditionally return true regardless of STA state, causing false positives
+// when the fallback AP is active.
+static bool wifi_sta_connected() {
+  int link = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+  IPAddress local = WiFi.localIP();
+  if (link == CYW43_LINK_JOIN && local.isSet()) {
+    // Verify the IP is a real STA IP, not the AP's IP leaking through
+    IPAddress ap_ip = WiFi.softAPIP();
+    if (local == ap_ip) {
+      ESP_LOGV(TAG, "wifi_sta_connected: localIP %s matches AP IP, ignoring", local.toString().c_str());
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
 // Track previous state for detecting changes
 static bool s_sta_was_connected = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static bool s_sta_had_ip = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static size_t s_scan_result_count = 0;    // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   if (sta.has_value()) {
     if (sta.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, true, CYW43_COUNTRY_WORLDWIDE);
+    } else {
+      // Leave the STA network so the radio is free for scanning.
+      // Use cyw43_wifi_leave directly to avoid corrupting Arduino framework state.
+      cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
     }
   }
 
-  bool ap_state = false;
   if (ap.has_value()) {
     if (ap.value()) {
       cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, true, CYW43_COUNTRY_WORLDWIDE);
-      ap_state = true;
+    } else {
+      cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_AP, false, CYW43_COUNTRY_WORLDWIDE);
     }
+    this->ap_started_ = ap.value();
   }
-  this->ap_started_ = ap_state;
   return true;
 }
 
@@ -77,8 +103,13 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
 #endif
 
-  auto ret = WiFi.begin(ap.get_ssid().c_str(), ap.get_password().c_str());
-  if (ret != WL_CONNECTED)
+  // Use beginNoBlock to avoid WiFi.begin()'s additional 2x timeout wait loop on top of
+  // CYW43::begin()'s internal blocking join. CYW43::begin() blocks for up to 10 seconds
+  // (default timeout) to complete the join - this is required because the LwipIntfDev netif
+  // setup depends on begin() succeeding. beginNoBlock() skips the outer wait loop, saving
+  // up to 20 additional seconds of blocking per attempt.
+  auto ret = WiFi.beginNoBlock(ap.ssid_.c_str(), ap.password_.c_str());
+  if (ret == WL_IDLE_STATUS)
     return false;
 
   return true;
@@ -114,14 +145,20 @@ const char *get_disconnect_reason_str(uint8_t reason) {
   return "UNKNOWN";
 }
 
-WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
-  int status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
+WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
+  // Use cyw43_wifi_link_status instead of cyw43_tcpip_link_status because the Arduino
+  // framework's __wrap_cyw43_cb_tcpip_init is a no-op — the SDK's internal netif
+  // (cyw43_state.netif[]) is never initialized. cyw43_tcpip_link_status checks that netif's
+  // flags and would only fall through to cyw43_wifi_link_status when the flags aren't set.
+  // Using cyw43_wifi_link_status directly gives us the actual WiFi radio join state.
+  int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
   switch (status) {
     case CYW43_LINK_JOIN:
-    case CYW43_LINK_NOIP:
+      // WiFi joined, check if STA has an IP address via wifi_sta_connected()
+      if (wifi_sta_connected()) {
+        return WiFiSTAConnectStatus::CONNECTED;
+      }
       return WiFiSTAConnectStatus::CONNECTING;
-    case CYW43_LINK_UP:
-      return WiFiSTAConnectStatus::CONNECTED;
     case CYW43_LINK_FAIL:
     case CYW43_LINK_BADAUTH:
       return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
@@ -137,10 +174,25 @@ int WiFiComponent::s_wifi_scan_result(void *env, const cyw43_ev_scan_result_t *r
 }
 
 void WiFiComponent::wifi_scan_result(void *env, const cyw43_ev_scan_result_t *result) {
+  s_scan_result_count++;
+
+  // CYW43 scan results have ssid as a 32-byte buffer that is NOT null-terminated.
+  // Use ssid_len to create a properly terminated copy for string operations.
+  uint8_t len = std::min(result->ssid_len, static_cast<uint8_t>(sizeof(result->ssid)));
+  char ssid_buf[33];  // 32 max + null terminator
+  memcpy(ssid_buf, result->ssid, len);
+  ssid_buf[len] = '\0';
+
+  // Skip networks that don't match any configured network (unless full results needed)
+  if (!this->needs_full_scan_results_() && !this->matches_configured_network_(ssid_buf, result->bssid)) {
+    this->log_discarded_scan_result_(ssid_buf, result->bssid, result->rssi, result->channel);
+    return;
+  }
+
   bssid_t bssid;
   std::copy(result->bssid, result->bssid + 6, bssid.begin());
-  std::string ssid(reinterpret_cast<const char *>(result->ssid));
-  WiFiScanResult res(bssid, ssid, result->channel, result->rssi, result->auth_mode != CYW43_AUTH_OPEN, ssid.empty());
+  WiFiScanResult res(bssid, ssid_buf, len, result->channel, result->rssi, result->auth_mode != CYW43_AUTH_OPEN,
+                     len == 0);
   if (std::find(this->scan_result_.begin(), this->scan_result_.end(), res) == this->scan_result_.end()) {
     this->scan_result_.push_back(res);
   }
@@ -149,6 +201,7 @@ void WiFiComponent::wifi_scan_result(void *env, const cyw43_ev_scan_result_t *re
 bool WiFiComponent::wifi_scan_start_(bool passive) {
   this->scan_result_.clear();
   this->scan_done_ = false;
+  s_scan_result_count = 0;
   cyw43_wifi_scan_options_t scan_options = {0};
   scan_options.scan_type = passive ? 1 : 0;
   int err = cyw43_wifi_scan(&cyw43_state, &scan_options, nullptr, &s_wifi_scan_result);
@@ -156,24 +209,13 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
     ESP_LOGV(TAG, "cyw43_wifi_scan failed");
   }
   return err == 0;
-  return true;
 }
 
 #ifdef USE_WIFI_AP
 bool WiFiComponent::wifi_ap_ip_config_(const optional<ManualIP> &manual_ip) {
-  esphome::network::IPAddress ip_address, gateway, subnet, dns;
-  if (manual_ip.has_value()) {
-    ip_address = manual_ip->static_ip;
-    gateway = manual_ip->gateway;
-    subnet = manual_ip->subnet;
-    dns = manual_ip->static_ip;
-  } else {
-    ip_address = network::IPAddress(192, 168, 4, 1);
-    gateway = network::IPAddress(192, 168, 4, 1);
-    subnet = network::IPAddress(255, 255, 255, 0);
-    dns = network::IPAddress(192, 168, 4, 1);
-  }
-  WiFi.config(ip_address, dns, gateway, subnet);
+  // AP IP is configured by WiFi.beginAP() internally using defaults (192.168.4.1).
+  // Manual AP IP has never worked on RP2040 — WiFi.config() configures the STA
+  // interface, not the AP. This is now rejected at config validation time.
   return true;
 }
 
@@ -192,17 +234,26 @@ bool WiFiComponent::wifi_start_ap_(const WiFiAP &ap) {
   }
 #endif
 
-  WiFi.beginAP(ap.get_ssid().c_str(), ap.get_password().c_str(), ap.has_channel() ? ap.get_channel() : 1);
+  // Pass nullptr for empty password — CYW43 uses the password pointer (not length)
+  // to choose between OPEN and WPA2 auth mode.
+  const char *ap_password = ap.password_.empty() ? nullptr : ap.password_.c_str();
+  WiFi.beginAP(ap.ssid_.c_str(), ap_password, ap.has_channel() ? ap.get_channel() : 1);
 
   return true;
 }
 
-network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {(const ip_addr_t *) WiFi.localIP()}; }
+network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {(const ip_addr_t *) WiFi.softAPIP()}; }
 #endif  // USE_WIFI_AP
 
 bool WiFiComponent::wifi_disconnect_() {
-  int err = cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
-  return err == 0;
+  // Use cyw43_wifi_leave() directly instead of WiFi.disconnect().
+  // WiFi.disconnect() sets _wifiHWInitted=false in the Arduino framework. beginAP()
+  // uses _wifiHWInitted to determine AP+STA vs AP-only mode — with it false,
+  // beginAP() enters AP-only mode (IP 192.168.42.1) instead of AP_STA mode
+  // (IP 192.168.4.1). In AP-only mode, _beginInternal() redirects all subsequent
+  // STA connect attempts to beginAP(), creating an infinite loop.
+  cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
+  return true;
 }
 
 bssid_t WiFiComponent::wifi_bssid() {
@@ -222,14 +273,22 @@ const char *WiFiComponent::wifi_ssid_to(std::span<char, SSID_BUFFER_SIZE> buffer
   buffer[len] = '\0';
   return buffer.data();
 }
-int8_t WiFiComponent::wifi_rssi() { return WiFi.status() == WL_CONNECTED ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
+int8_t WiFiComponent::wifi_rssi() { return this->is_connected_() ? WiFi.RSSI() : WIFI_RSSI_DISCONNECTED; }
 int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 
 network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   network::IPAddresses addresses;
   uint8_t index = 0;
+  // Filter out AP interface addresses — addrList includes all lwIP netifs.
+  // The AP netif IP lingers even after the AP radio is disabled.
+  IPAddress ap_ip = WiFi.softAPIP();
   for (auto addr : addrList) {
-    addresses[index++] = addr.ipFromNetifNum();
+    IPAddress ip(addr.ipFromNetifNum());
+    if (ip == ap_ip) {
+      continue;
+    }
+    assert(index < addresses.size());
+    addresses[index++] = ip;
   }
   return addresses;
 }
@@ -240,23 +299,26 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
   return network::IPAddress(dns_ip);
 }
 
+// Pico W uses polling for connection state detection.
+// Connect state listener notifications are deferred until after the state machine
+// transitions (in check_connecting_finished) so that conditions like wifi.connected
+// return correct values in automations.
 void WiFiComponent::wifi_loop_() {
   // Handle scan completion
   if (this->state_ == WIFI_COMPONENT_STATE_STA_SCANNING && !cyw43_wifi_scan_active(&cyw43_state)) {
     this->scan_done_ = true;
-    ESP_LOGV(TAG, "Scan done");
+    bool needs_full = this->needs_full_scan_results_();
+    ESP_LOGV(TAG, "Scan complete: %zu found, %zu stored%s", s_scan_result_count, this->scan_result_.size(),
+             needs_full ? "" : " (filtered)");
 #ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
-    for (auto *listener : this->scan_results_listeners_) {
-      listener->on_wifi_scan_results(this->scan_result_);
-    }
+    this->notify_scan_results_listeners_();
 #endif
   }
 
   // Poll for connection state changes
   // The arduino-pico WiFi library doesn't have event callbacks like ESP8266/ESP32,
-  // so we need to poll the link status to detect state changes
-  auto status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
-  bool is_connected = (status == CYW43_LINK_UP);
+  // so we need to poll the link status to detect state changes.
+  bool is_connected = wifi_sta_connected();
 
   // Detect connection state change
   if (is_connected && !s_sta_was_connected) {
@@ -264,19 +326,15 @@ void WiFiComponent::wifi_loop_() {
     s_sta_was_connected = true;
     ESP_LOGV(TAG, "Connected");
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-    String ssid = WiFi.SSID();
-    bssid_t bssid = this->wifi_bssid();
-    for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(ssid.c_str(), ssid.length()), bssid);
-    }
+    // Defer listener notification until state machine reaches STA_CONNECTED
+    // This ensures wifi.connected condition returns true in listener automations
+    this->pending_.connect_state = true;
 #endif
     // For static IP configurations, notify IP listeners immediately as the IP is already configured
 #if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)
     if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
       s_sta_had_ip = true;
-      for (auto *listener : this->ip_state_listeners_) {
-        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-      }
+      this->notify_ip_state_listeners_();
     }
 #endif
   } else if (!is_connected && s_sta_was_connected) {
@@ -285,10 +343,7 @@ void WiFiComponent::wifi_loop_() {
     s_sta_had_ip = false;
     ESP_LOGV(TAG, "Disconnected");
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-    static constexpr uint8_t EMPTY_BSSID[6] = {};
-    for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(), EMPTY_BSSID);
-    }
+    this->notify_disconnect_state_listeners_();
 #endif
   }
 
@@ -306,9 +361,7 @@ void WiFiComponent::wifi_loop_() {
       s_sta_had_ip = true;
       ESP_LOGV(TAG, "Got IP address");
 #ifdef USE_WIFI_IP_STATE_LISTENERS
-      for (auto *listener : this->ip_state_listeners_) {
-        listener->on_ip_state(this->wifi_sta_ip_addresses(), this->get_dns_address(0), this->get_dns_address(1));
-      }
+      this->notify_ip_state_listeners_();
 #endif
     }
   }


### PR DESCRIPTION
## Summary
- sync custom `wifi` component with ESPHome `2026.3.0`
- keep marsrelay AP+STA behavior by preserving the custom patch:
  - keep AP enabled after STA connect
  - start AP immediately when AP config exists (instead of waiting for `ap_timeout`)
- rebase `capture_dns` fork on latest ESPHome `captive_portal` DNS implementation and reapply standalone DNS-only patch
- migrate socket type usage for 2026.3 socket devirtualization (`ListenSocket` where appropriate)
- update CI layout to a reusable dispatch workflow with:
  - push/PR workflow pinned to ESPHome `2026.3.0`
  - nightly workflow running against `latest`
- add missing `synchronous=True` for `mosquitto_broker.publish_message` action registration

## Issues fixed
- Fixes #11 — `get_loop_priority()` guard requirement (`USE_LOOP_PRIORITY`) is satisfied by syncing to latest wifi component
- Fixes #12 — socket abstraction devirtualization migration (`ListenSocket` updates in `udp_proxy` and `shelly_emulator`, plus updated `capture_dns` DNS server fork)

## Validation
- `esphome config marsrelay_esp32s3.yaml` passes
- local tests: `pytest -q` → `2 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable CI workflow plus daily Nightly CI run for automated builds and tests

* **New Features**
  * WiFi band selection support (AUTO, 2.4GHz, 5GHz) for ESP32c5

* **Improvements**
  * Enhanced WiFi: output-power handling, scan filtering, listener/connection-state notifications, and stability across platforms
  * Reduced DNS server log verbosity and improved socket handling

* **Changes**
  * Mosquitto broker publish_message action now runs synchronously
  * RP2040 now rejects manual AP IP configuration in validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->