### PR TITLE
fix(mosquitto_broker): increase broker task stack to 12 KiB

### DIFF
--- a/components/mosquitto_broker/mosquitto_broker.cpp
+++ b/components/mosquitto_broker/mosquitto_broker.cpp
@@ -106,7 +106,9 @@ void MosquittoBroker::setup() {
 void MosquittoBroker::loop() {
   if (!this->broker_started_ && esphome::millis() - this->broker_start_at_ > 1000) {
     if (this->broker_task_handle_ == nullptr) {
-      xTaskCreate(&MosquittoBroker::broker_task_, "mosq_broker", 4096, this, 5, &this->broker_task_handle_);
+      // 12 KiB stack: mbedTLS handshakes inside the broker task can use 8 KiB+ on
+      // their own, so 4 KiB overflowed as soon as a TLS client connected.
+      xTaskCreate(&MosquittoBroker::broker_task_, "mosq_broker", 12288, this, 5, &this->broker_task_handle_);
     }
     this->broker_started_ = true;
     // Wait a bit longer for broker to be ready before connecting publish client

--- a/components/mosquitto_broker/mosquitto_broker.cpp
+++ b/components/mosquitto_broker/mosquitto_broker.cpp
@@ -108,7 +108,14 @@ void MosquittoBroker::loop() {
     if (this->broker_task_handle_ == nullptr) {
       // 12 KiB stack: mbedTLS handshakes inside the broker task can use 8 KiB+ on
       // their own, so 4 KiB overflowed as soon as a TLS client connected.
-      xTaskCreate(&MosquittoBroker::broker_task_, "mosq_broker", 12288, this, 5, &this->broker_task_handle_);
+      BaseType_t rc = xTaskCreate(&MosquittoBroker::broker_task_, "mosq_broker", 12288, this, 5,
+                                  &this->broker_task_handle_);
+      if (rc != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create mosq_broker task (rc=%d), will retry", (int) rc);
+        this->broker_task_handle_ = nullptr;
+        this->broker_start_at_ = esphome::millis();  // back off ~1s before retrying
+        return;
+      }
     }
     this->broker_started_ = true;
     // Wait a bit longer for broker to be ready before connecting publish client


### PR DESCRIPTION
The mosq_broker FreeRTOS task ran with a 4 KiB stack, which overflowed during TLS handshakes (mbedTLS uses 8 KiB+ on the stack on its own). Once the task crashed the ESP rebooted, dropping the Marstek device's local broker connection and preventing forwarded App/.../ctrl messages (e.g. cd=1) from ever reaching the device.

Refs #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of the Mosquitto broker component during TLS secure connection handshakes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/marsrelay/pull/22)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->