### PR TITLE
Add MQTT topic ID mapping for device identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,39 @@ Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://githu
 
 ---
 
+## Optional: Battery ID Mapping (Issue #19)
+
+Marstek batteries use a long ID in their cloud MQTT topics, while
+[hm2mqtt](https://github.com/tomquist/hm2mqtt) and
+[Hame Relay](https://github.com/tomquist/hame-relay) expect the battery's
+Bluetooth MAC address as the device ID. To bridge the two, marsrelay can
+rewrite the ID segment of every topic it forwards.
+
+Add an `id_mappings` list to the `mosquitto_broker:` block:
+
+```yaml
+mosquitto_broker:
+  id: local_broker
+  # ...existing options...
+  id_mappings:
+    - device: "<long-id-from-cloud-mqtt-topic>"
+      external: "<bluetooth-mac-address>"
+```
+
+For each pair, `device` is the long ID that appears in the topic on the local
+mosquitto broker (the one the battery uses for its cloud MQTT topics), and
+`external` is the Bluetooth MAC address that hm2mqtt / Hame Relay use as the
+device ID. Translation is applied in both directions automatically: control
+messages from hm2mqtt on `.../App/<external>/...` are rewritten to
+`.../App/<device>/...` before being delivered to the battery, and status
+messages from the battery on `.../device/<device>/...` are rewritten to
+`.../device/<external>/...` before being forwarded out.
+
+Use the `external` ID (the Bluetooth MAC) in your hm2mqtt / Hame Relay
+configuration.
+
+---
+
 ## Optional: Shelly UDP Emulator (Issue #6)
 
 Marsrelay can emulate a Shelly Gen2 energy meter (UDP JSON-RPC) using ESPHome sensor values.

--- a/components/mosquitto_broker/__init__.py
+++ b/components/mosquitto_broker/__init__.py
@@ -13,6 +13,9 @@ CONF_ON_MESSAGE = "on_message"
 CONF_MAX_CLIENTS = "max_clients"
 CONF_TLS = "tls"
 CONF_TLS_SKIP_VERIFICATION = "tls_skip_verification"
+CONF_ID_MAPPINGS = "id_mappings"
+CONF_DEVICE = "device"
+CONF_EXTERNAL = "external"
 
 mosquitto_broker_ns = cg.esphome_ns.namespace("mosquitto_broker")
 MosquittoBroker = mosquitto_broker_ns.class_("MosquittoBroker", cg.Component)
@@ -33,6 +36,14 @@ CONFIG_SCHEMA = (
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MosquittoMessageTrigger),
                 }
+            ),
+            cv.Optional(CONF_ID_MAPPINGS, default=[]): cv.ensure_list(
+                cv.Schema(
+                    {
+                        cv.Required(CONF_DEVICE): cv.string_strict,
+                        cv.Required(CONF_EXTERNAL): cv.string_strict,
+                    }
+                )
             ),
         }
     )
@@ -62,6 +73,9 @@ async def to_code(config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.add_message_trigger(trigger))
         await automation.build_automation(trigger, [(cg.std_string, "topic"), (cg.std_string, "payload")], conf)
+
+    for mapping in config.get(CONF_ID_MAPPINGS, []):
+        cg.add(var.add_id_mapping(mapping[CONF_DEVICE], mapping[CONF_EXTERNAL]))
 
 
 @automation.register_action(

--- a/components/mosquitto_broker/__init__.py
+++ b/components/mosquitto_broker/__init__.py
@@ -17,6 +17,61 @@ CONF_ID_MAPPINGS = "id_mappings"
 CONF_DEVICE = "device"
 CONF_EXTERNAL = "external"
 
+# Topic segments that have structural meaning in the marsrelay bridge. If a
+# mapping's `device` or `external` value collided with one of these, the
+# translator would rewrite the structural segment and break the `/device/`
+# filter the local->external bridge relies on, which can in turn enable a
+# forwarding loop. Reject up front instead.
+RESERVED_ID_SEGMENTS = frozenset(
+    {"marstek_energy", "App", "device", "ctrl"}
+)
+
+
+def _validate_id_segment(value):
+    value = cv.string_strict(value)
+    if not value:
+        raise cv.Invalid("ID must not be empty")
+    if "/" in value:
+        raise cv.Invalid("ID must not contain '/' (it is a single topic segment)")
+    if "+" in value or "#" in value:
+        raise cv.Invalid("ID must not contain MQTT wildcard characters ('+' or '#')")
+    if value in RESERVED_ID_SEGMENTS:
+        raise cv.Invalid(
+            f"ID must not be one of the reserved topic segments: "
+            f"{', '.join(sorted(RESERVED_ID_SEGMENTS))}"
+        )
+    return value
+
+
+def _validate_id_mappings(value):
+    seen_devices = set()
+    seen_externals = set()
+    for index, mapping in enumerate(value):
+        device = mapping[CONF_DEVICE]
+        external = mapping[CONF_EXTERNAL]
+        if device == external:
+            raise cv.Invalid(
+                f"id_mappings[{index}]: 'device' and 'external' must differ "
+                f"(both were '{device}')"
+            )
+        if device in seen_devices:
+            raise cv.Invalid(
+                f"id_mappings[{index}]: duplicate device id '{device}'"
+            )
+        if external in seen_externals:
+            raise cv.Invalid(
+                f"id_mappings[{index}]: duplicate external id '{external}'"
+            )
+        if device in seen_externals or external in seen_devices:
+            raise cv.Invalid(
+                f"id_mappings[{index}]: id '{device if device in seen_externals else external}' "
+                f"is used on both sides across mappings, which would cause ambiguous translation"
+            )
+        seen_devices.add(device)
+        seen_externals.add(external)
+    return value
+
+
 mosquitto_broker_ns = cg.esphome_ns.namespace("mosquitto_broker")
 MosquittoBroker = mosquitto_broker_ns.class_("MosquittoBroker", cg.Component)
 MosquittoMessageTrigger = mosquitto_broker_ns.class_(
@@ -37,13 +92,16 @@ CONFIG_SCHEMA = (
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(MosquittoMessageTrigger),
                 }
             ),
-            cv.Optional(CONF_ID_MAPPINGS, default=[]): cv.ensure_list(
-                cv.Schema(
-                    {
-                        cv.Required(CONF_DEVICE): cv.string_strict,
-                        cv.Required(CONF_EXTERNAL): cv.string_strict,
-                    }
-                )
+            cv.Optional(CONF_ID_MAPPINGS, default=[]): cv.All(
+                cv.ensure_list(
+                    cv.Schema(
+                        {
+                            cv.Required(CONF_DEVICE): _validate_id_segment,
+                            cv.Required(CONF_EXTERNAL): _validate_id_segment,
+                        }
+                    )
+                ),
+                _validate_id_mappings,
             ),
         }
     )

--- a/components/mosquitto_broker/mosquitto_broker.cpp
+++ b/components/mosquitto_broker/mosquitto_broker.cpp
@@ -153,6 +153,7 @@ void MosquittoBroker::dump_config() {
     ESP_LOGCONFIG(TAG, "  Skip Verification: %s", this->tls_skip_verification_ ? "Yes" : "No");
   }
   ESP_LOGCONFIG(TAG, "  Max Clients: %u", this->max_clients_);
+  ESP_LOGCONFIG(TAG, "  ID Mappings: %u", (unsigned) this->id_mappings_.size());
 }
 
 void MosquittoBroker::publish_message(const std::string &topic, const std::string &payload) {
@@ -167,11 +168,78 @@ void MosquittoBroker::publish_message(const std::string &topic, const std::strin
     ESP_LOGW(TAG, "Publish client not connected, skipping publish");
     return;
   }
-  
-  int msg_id = esp_mqtt_client_publish(this->esp_mqtt_client_, topic.c_str(), payload.c_str(), payload.length(), 0, 0);
-  if (msg_id < 0) {
-    ESP_LOGW(TAG, "Publish failed for %s (error: %d)", topic.c_str(), msg_id);
+
+  std::string translated = this->translate_external_to_device_(topic);
+  if (translated != topic) {
+    ESP_LOGV(TAG, "Translated external topic '%s' to device topic '%s'", topic.c_str(), translated.c_str());
   }
+
+  int msg_id = esp_mqtt_client_publish(this->esp_mqtt_client_, translated.c_str(), payload.c_str(), payload.length(), 0, 0);
+  if (msg_id < 0) {
+    ESP_LOGW(TAG, "Publish failed for %s (error: %d)", translated.c_str(), msg_id);
+  }
+}
+
+std::string MosquittoBroker::translate_external_to_device_(const std::string &topic) const {
+  if (this->id_mappings_.empty()) {
+    return topic;
+  }
+  std::string result;
+  result.reserve(topic.size());
+  size_t pos = 0;
+  while (pos <= topic.size()) {
+    size_t next = topic.find('/', pos);
+    size_t end = (next == std::string::npos) ? topic.size() : next;
+    bool replaced = false;
+    for (const auto &mapping : this->id_mappings_) {
+      const std::string &external = mapping.second;
+      if (end - pos == external.size() && topic.compare(pos, external.size(), external) == 0) {
+        result.append(mapping.first);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      result.append(topic, pos, end - pos);
+    }
+    if (next == std::string::npos) {
+      break;
+    }
+    result.push_back('/');
+    pos = next + 1;
+  }
+  return result;
+}
+
+std::string MosquittoBroker::translate_device_to_external_(const std::string &topic) const {
+  if (this->id_mappings_.empty()) {
+    return topic;
+  }
+  std::string result;
+  result.reserve(topic.size());
+  size_t pos = 0;
+  while (pos <= topic.size()) {
+    size_t next = topic.find('/', pos);
+    size_t end = (next == std::string::npos) ? topic.size() : next;
+    bool replaced = false;
+    for (const auto &mapping : this->id_mappings_) {
+      const std::string &device = mapping.first;
+      if (end - pos == device.size() && topic.compare(pos, device.size(), device) == 0) {
+        result.append(mapping.second);
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      result.append(topic, pos, end - pos);
+    }
+    if (next == std::string::npos) {
+      break;
+    }
+    result.push_back('/');
+    pos = next + 1;
+  }
+  return result;
 }
 
 void MosquittoBroker::broker_task_(void *param) {
@@ -200,8 +268,13 @@ void MosquittoBroker::handle_message_(char *topic, char *data, int len) {
   std::string topic_str(topic);
   std::string payload(data, len);
 
+  std::string translated = this->translate_device_to_external_(topic_str);
+  if (translated != topic_str) {
+    ESP_LOGV(TAG, "Translated device topic '%s' to external topic '%s'", topic_str.c_str(), translated.c_str());
+  }
+
   for (auto *trigger : this->message_triggers_) {
-    trigger->trigger(topic_str, payload);
+    trigger->trigger(translated, payload);
   }
 }
 

--- a/components/mosquitto_broker/mosquitto_broker.h
+++ b/components/mosquitto_broker/mosquitto_broker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "esphome/core/component.h"
@@ -43,6 +44,9 @@ class MosquittoBroker : public Component {
   void publish_message(const std::string &topic, const std::string &payload);
   void add_message_trigger(MosquittoMessageTrigger *trigger) { this->message_triggers_.push_back(trigger); }
   void set_publish_state(mqtt::MQTTClientState state) { this->publish_state_ = state; }
+  void add_id_mapping(const std::string &device, const std::string &external) {
+    this->id_mappings_.emplace_back(device, external);
+  }
 
  protected:
   static void broker_task_(void *param);
@@ -50,6 +54,8 @@ class MosquittoBroker : public Component {
 
   void handle_message_(char *topic, char *data, int len);
   void ensure_publish_client_();
+  std::string translate_external_to_device_(const std::string &topic) const;
+  std::string translate_device_to_external_(const std::string &topic) const;
 
   uint16_t port_{1883};
   uint16_t max_clients_{20};
@@ -64,6 +70,7 @@ class MosquittoBroker : public Component {
   uint32_t connect_begin_{0};
   esp_mqtt_client_handle_t esp_mqtt_client_{nullptr};
   std::vector<MosquittoMessageTrigger *> message_triggers_;
+  std::vector<std::pair<std::string, std::string>> id_mappings_;
 };
 
 template<typename... Ts> class PublishMessageAction : public Action<Ts...> {

--- a/tests/component_tests/mosquitto_broker/test_id_mappings.py
+++ b/tests/component_tests/mosquitto_broker/test_id_mappings.py
@@ -1,14 +1,96 @@
 from pathlib import Path
 
+import pytest
+
+
+FIXTURE = (
+    Path(__file__).parents[3] / "tests" / "fixtures" / "mosquitto_broker_id_mappings.yaml"
+)
+
 
 def test_mosquitto_broker_id_mappings_generation(generate_main):
-    fixture = (
-        Path(__file__).parents[3] / "tests" / "fixtures" / "mosquitto_broker_id_mappings.yaml"
-    )
-    main_cpp = generate_main(str(fixture))
+    main_cpp = generate_main(str(FIXTURE))
     assert "mosquitto_broker::MosquittoBroker" in main_cpp
     assert "add_id_mapping(" in main_cpp
     assert "1111111111111111111111111111111111111111111111111111111111111111" in main_cpp
     assert "aabbccddeeff" in main_cpp
     assert "22222222222222222222222222222222" in main_cpp
     assert "aabbccddee00" in main_cpp
+
+
+def _validate(mappings):
+    from components.mosquitto_broker import _validate_id_mappings, _validate_id_segment
+
+    normalised = []
+    for mapping in mappings:
+        normalised.append(
+            {
+                "device": _validate_id_segment(mapping["device"]),
+                "external": _validate_id_segment(mapping["external"]),
+            }
+        )
+    return _validate_id_mappings(normalised)
+
+
+@pytest.mark.parametrize(
+    "device, external, message",
+    [
+        ("device", "abcd", "reserved"),
+        ("abcd", "App", "reserved"),
+        ("ctrl", "abcd", "reserved"),
+        ("marstek_energy", "abcd", "reserved"),
+        ("", "abcd", "empty"),
+        ("abcd", "", "empty"),
+        ("ab/cd", "abcd", "'/'"),
+        ("abcd", "ab+cd", "wildcard"),
+        ("abcd", "ab#cd", "wildcard"),
+    ],
+)
+def test_segment_rejected(device, external, message):
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match=message):
+        _validate([{"device": device, "external": external}])
+
+
+def test_same_device_and_external_rejected():
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match="must differ"):
+        _validate([{"device": "same", "external": "same"}])
+
+
+def test_duplicate_device_rejected():
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match="duplicate device"):
+        _validate(
+            [
+                {"device": "A", "external": "B"},
+                {"device": "A", "external": "C"},
+            ]
+        )
+
+
+def test_duplicate_external_rejected():
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match="duplicate external"):
+        _validate(
+            [
+                {"device": "A", "external": "X"},
+                {"device": "B", "external": "X"},
+            ]
+        )
+
+
+def test_id_used_on_both_sides_rejected():
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match="both sides"):
+        _validate(
+            [
+                {"device": "A", "external": "B"},
+                {"device": "B", "external": "C"},
+            ]
+        )

--- a/tests/component_tests/mosquitto_broker/test_id_mappings.py
+++ b/tests/component_tests/mosquitto_broker/test_id_mappings.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_mosquitto_broker_id_mappings_generation(generate_main):
+    fixture = (
+        Path(__file__).parents[3] / "tests" / "fixtures" / "mosquitto_broker_id_mappings.yaml"
+    )
+    main_cpp = generate_main(str(fixture))
+    assert "mosquitto_broker::MosquittoBroker" in main_cpp
+    assert "add_id_mapping(" in main_cpp
+    assert "1111111111111111111111111111111111111111111111111111111111111111" in main_cpp
+    assert "aabbccddeeff" in main_cpp
+    assert "22222222222222222222222222222222" in main_cpp
+    assert "aabbccddee00" in main_cpp

--- a/tests/fixtures/mosquitto_broker_id_mappings.yaml
+++ b/tests/fixtures/mosquitto_broker_id_mappings.yaml
@@ -1,0 +1,37 @@
+esphome:
+  name: test-mqtt-id-mappings
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+external_components:
+  - source:
+      type: local
+      path: ../../components
+
+wifi:
+  ssid: "test"
+  password: "testpass"
+  ap:
+    ssid: "fallback"
+    password: "fallbackpass"
+
+logger:
+
+mqtt:
+  broker: 127.0.0.1
+  username: "user"
+  password: "pass"
+
+mosquitto_broker:
+  id: local_broker
+  tls: false
+  port: 1883
+  id_mappings:
+    - device: "1111111111111111111111111111111111111111111111111111111111111111"
+      external: "aabbccddeeff"
+    - device: "22222222222222222222222222222222"
+      external: "aabbccddee00"


### PR DESCRIPTION
## Summary
This PR adds support for mapping between device-native IDs and external aliases in MQTT topics. This allows users to translate long cryptic firmware IDs to shorter, more practical identifiers on their home MQTT broker.

## Key Changes
- **Topic translation logic**: Added two new translation methods (`translate_external_to_device_` and `translate_device_to_external_`) that perform bidirectional ID mapping on MQTT topics by replacing ID segments between forward slashes
- **Configuration support**: Extended the `mosquitto_broker` component to accept an `id_mappings` list with `device` (firmware ID) and `external` (alias) pairs
- **Publish message handling**: Updated `publish_message()` to translate external topic IDs to device IDs before publishing to the local broker
- **Message handling**: Updated `handle_message_()` to translate device topic IDs to external IDs before triggering message handlers
- **Logging**: Added debug logging for topic translations and a config dump line showing the number of active ID mappings
- **Tests and documentation**: Added fixture configuration, component test, and README documentation explaining the feature and use case

## Implementation Details
- ID mapping is performed at the topic segment level (between `/` delimiters) to ensure only complete ID segments are replaced
- Translation functions early-return if no mappings are configured for performance
- The implementation uses string comparison and `std::string::compare()` for efficient segment matching
- Mappings are stored as a vector of device-external ID pairs for simple linear lookup

https://claude.ai/code/session_01BhdrXHwWSrMJuSsERit5X5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional battery ID mapping configuration to translate topic IDs between cloud MQTT identifiers and Bluetooth device MAC addresses
  * Bidirectional topic rewriting automatically applied to control and status messages

* **Documentation**
  * Added configuration guide for setting up battery ID mappings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/marsrelay/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->