### PR TITLE
Upgrade ESPHome to 2026.5.0 and add WiFi PHY mode support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,5 @@ jobs:
   ci:
     uses: ./.github/workflows/ci-dispatch.yml
     with:
-      esphome_version: "2026.3.0"
+      esphome_version: "2026.5.0"
       run_tests: true

--- a/components/wifi/README.md
+++ b/components/wifi/README.md
@@ -1,0 +1,71 @@
+# wifi (forked from ESPHome)
+
+This is a fork of ESPHome's built-in `wifi` component. It exists solely to
+allow the **fallback AP / captive portal to run simultaneously with the STA
+connection**, which upstream does not support — upstream treats AP mode as a
+fallback that shuts down as soon as the STA associates.
+
+## Current base
+
+- **Upstream version:** `2026.5.0`
+- **Upstream source:** <https://github.com/esphome/esphome/tree/2026.5.0/esphome/components/wifi>
+
+Everything in this directory is byte-for-byte identical to that upstream
+revision except for the patches described below.
+
+## The patch (AP + STA simultaneously)
+
+There are exactly **two changes**, both in `wifi_component.cpp`, both marked
+with a `// marsrelay:` comment so they're easy to find:
+
+1. **Always start the fallback AP.**
+   Upstream only starts the AP after `ap_timeout_` has elapsed since
+   `last_connected_`. We start it unconditionally so it's available from boot,
+   regardless of STA state.
+
+2. **Keep the AP enabled after STA connects.**
+   Upstream calls `this->wifi_mode_({}, false)` to disable the AP once the STA
+   associates. We skip that call so AP+STA stay up together.
+
+To see the exact diff against upstream:
+
+```sh
+git clone --depth 1 --branch <version> https://github.com/esphome/esphome.git /tmp/esphome
+diff -ruN /tmp/esphome/esphome/components/wifi components/wifi
+```
+
+Expect only the two `// marsrelay:` hunks in `wifi_component.cpp`.
+
+## Updating to a newer ESPHome release
+
+When the nightly build breaks (or you want to bump ESPHome), re-fork rather
+than patching incrementally — upstream changes too much between releases for
+hand-merging to be safe:
+
+1. Pick the new upstream version, e.g. `2026.X.Y`.
+2. Clone upstream at that tag and copy `esphome/components/wifi/*` over this
+   directory (preserve this `README.md`):
+   ```sh
+   git clone --depth 1 --branch 2026.X.Y https://github.com/esphome/esphome.git /tmp/esphome
+   cp /tmp/esphome/esphome/components/wifi/{*.py,*.h,*.cpp} components/wifi/
+   ```
+3. Re-apply the two `// marsrelay:` patches in `wifi_component.cpp`. Search
+   upstream for the anchor lines `ESP_LOGI(TAG, "Starting fallback AP")` and
+   `ESP_LOGD(TAG, "Disabling AP")` to locate the spots.
+4. Bump `esphome_version` in `.github/workflows/ci.yml` (and ensure the
+   nightly's `latest` still resolves to the same major version, or pin it).
+5. Verify:
+   ```sh
+   esphome config marsrelay_esp32s3.yaml
+   esphome config tests/fixtures/shelly_emulator.yaml
+   pytest -q tests/
+   ```
+6. Update the **Current base** version at the top of this file.
+
+## Why a full fork (instead of a small override)
+
+ESPHome's wifi component doesn't expose an extension point for "keep AP up
+after STA connects", and the AP/STA mode transitions are tangled into private
+methods of `WiFiComponent`. Subclassing or monkey-patching from a small
+component would be more fragile than carrying the two-line patch on a full
+fork.

--- a/components/wifi/__init__.py
+++ b/components/wifi/__init__.py
@@ -54,10 +54,16 @@ from esphome.const import (
     CONF_TTLS_PHASE_2,
     CONF_USE_ADDRESS,
     CONF_USERNAME,
+    CONF_WIFI,
     Platform,
     PlatformFramework,
 )
-from esphome.core import CORE, CoroPriority, HexInt, coroutine_with_priority
+
+try:
+    from esphome.const import PLACEHOLDER_WIFI_SSID
+except ImportError:  # ESPHome < 2026.5.0
+    PLACEHOLDER_WIFI_SSID = "REPLACE_WITH_YOUR_WIFI_NETWORK"
+from esphome.core import CORE, CoroPriority, EsphomeError, HexInt, coroutine_with_priority
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
@@ -120,6 +126,44 @@ WiFiDisableAction = wifi_ns.class_("WiFiDisableAction", automation.Action)
 WiFiConfigureAction = wifi_ns.class_(
     "WiFiConfigureAction", automation.Action, cg.Component
 )
+
+
+def _placeholder_wifi_credentials(config: ConfigType) -> list[str]:
+    """Return locations where the dashboard's placeholder wifi SSID still appears."""
+    placeholders: list[str] = []
+    wifi_conf = config.get(CONF_WIFI)
+    if not wifi_conf:
+        return placeholders
+
+    for idx, network in enumerate(wifi_conf.get(CONF_NETWORKS, [])):
+        ssid = network.get(CONF_SSID)
+        if isinstance(ssid, str) and ssid == PLACEHOLDER_WIFI_SSID:
+            placeholders.append(f"wifi.networks[{idx}].ssid")
+
+    ap_conf = wifi_conf.get(CONF_AP)
+    if ap_conf:
+        ap_ssid = ap_conf.get(CONF_SSID)
+        if isinstance(ap_ssid, str) and ap_ssid == PLACEHOLDER_WIFI_SSID:
+            placeholders.append("wifi.ap.ssid")
+
+    return placeholders
+
+
+def check_placeholder_credentials(config: ConfigType) -> None:
+    """Raise EsphomeError if any wifi credential is the dashboard placeholder.
+
+    Called by ESPHome 2026.5.0+ at compile time.
+    """
+    locations = _placeholder_wifi_credentials(config)
+    if not locations:
+        return
+    formatted = ", ".join(locations)
+    raise EsphomeError(
+        f"wifi configuration still contains the dashboard placeholder value "
+        f"'{PLACEHOLDER_WIFI_SSID}' at: {formatted}. "
+        f"Open secrets.yaml and replace 'wifi_ssid' (and 'wifi_password') "
+        f"with your real wifi credentials before flashing."
+    )
 
 
 def validate_password(value):

--- a/components/wifi/__init__.py
+++ b/components/wifi/__init__.py
@@ -55,15 +55,17 @@ from esphome.const import (
     CONF_USE_ADDRESS,
     CONF_USERNAME,
     CONF_WIFI,
+    PLACEHOLDER_WIFI_SSID,
     Platform,
     PlatformFramework,
 )
-
-try:
-    from esphome.const import PLACEHOLDER_WIFI_SSID
-except ImportError:  # ESPHome < 2026.5.0
-    PLACEHOLDER_WIFI_SSID = "REPLACE_WITH_YOUR_WIFI_NETWORK"
-from esphome.core import CORE, CoroPriority, EsphomeError, HexInt, coroutine_with_priority
+from esphome.core import (
+    CORE,
+    CoroPriority,
+    EsphomeError,
+    HexInt,
+    coroutine_with_priority,
+)
 import esphome.final_validate as fv
 from esphome.types import ConfigType
 
@@ -73,12 +75,76 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["network"]
 
-_LOGGER = logging.getLogger(__name__)
-
 NO_WIFI_VARIANTS = [const.VARIANT_ESP32H2, const.VARIANT_ESP32P4]
+
+
+def variant_has_wifi(variant: str) -> bool:
+    """Return True if *variant* has a native WiFi PHY.
+
+    Variants without a native PHY (ESP32-H2, ESP32-P4) need the
+    ``esp32_hosted`` co-processor to use ``wifi:``.
+
+    Case-insensitive on *variant* so external callers can pass either
+    the upstream uppercase form (e.g. ``"ESP32H2"`` from
+    ``const.VARIANT_ESP32H2``) or a lowercase form their own enum
+    surfaces (e.g. ``"esp32h2"`` from device-builder's
+    ``Esp32Variant``). Both classify identically.
+
+    Used by device-builder (esphome/device-builder) to decide whether
+    its basic-setup wizard emits a ``wifi:`` block — please keep the
+    signature stable.
+    """
+    return variant.upper() not in NO_WIFI_VARIANTS
+
+
+_WIFI_FIRST_PLATFORMS: frozenset[str] = frozenset(
+    {
+        Platform.ESP8266,
+        Platform.BK72XX,
+        Platform.RTL87XX,
+        Platform.LN882X,
+        # Legacy umbrella key for the LibreTiny families (bk72xx /
+        # rtl87xx / ln882x); still produced by older configs that
+        # haven't migrated to the per-family keys.
+        Platform.LIBRETINY_OLDSTYLE,
+    }
+)
+
+
+def has_native_wifi(
+    *, platform: str, board: str | None = None, variant: str | None = None
+) -> bool:
+    """Return True when the given platform/board/variant has native WiFi.
+
+    Single dispatch entry point for tooling that needs to decide
+    whether emitting a ``wifi:`` block produces a compilable
+    config. Caller passes whichever platform-relevant fields they
+    have (``variant`` for ESP32, ``board`` for RP2040), and this
+    function routes to the right per-platform check internally.
+
+    Allowlist-based: unknown / Wi-Fi-less platforms (``host``,
+    ``nrf52``) return False so a future platform added to ESPHome
+    fails closed in external tooling rather than silently emitting
+    a ``wifi:`` block the new platform's component would reject.
+
+    Used by device-builder (esphome/device-builder)'s basic-setup
+    wizard. Centralised here so callers don't have to special-case
+    each platform — as ESPHome adds new platforms, this dispatcher
+    is the one place to teach them about Wi-Fi capability.
+    """
+    if platform == Platform.ESP32:
+        return variant_has_wifi(variant) if variant else True
+    if platform == Platform.RP2040:
+        from esphome.components.rp2040 import board_id_has_wifi
+
+        return board_id_has_wifi(board) if board else True
+    return platform in _WIFI_FIRST_PLATFORMS
+
+
 CONF_SAVE = "save"
 CONF_BAND_MODE = "band_mode"
 CONF_MIN_AUTH_MODE = "min_auth_mode"
+CONF_PHY_MODE = "phy_mode"
 CONF_POST_CONNECT_ROAMING = "post_connect_roaming"
 
 # Maximum number of WiFi networks that can be configured
@@ -118,6 +184,14 @@ WIFI_MIN_AUTH_MODES = {
     "WPA3": WifiMinAuthMode.WIFI_MIN_AUTH_MODE_WPA3,
 }
 VALIDATE_WIFI_MIN_AUTH_MODE = cv.enum(WIFI_MIN_AUTH_MODES, upper=True)
+
+WiFi8266PhyMode = wifi_ns.enum("WiFi8266PhyMode")
+WIFI_8266_PHY_MODES = {
+    "AUTO": WiFi8266PhyMode.WIFI_8266_PHY_MODE_AUTO,
+    "11B": WiFi8266PhyMode.WIFI_8266_PHY_MODE_11B,
+    "11G": WiFi8266PhyMode.WIFI_8266_PHY_MODE_11G,
+    "11N": WiFi8266PhyMode.WIFI_8266_PHY_MODE_11N,
+}
 WiFiConnectedCondition = wifi_ns.class_("WiFiConnectedCondition", Condition)
 WiFiEnabledCondition = wifi_ns.class_("WiFiEnabledCondition", Condition)
 WiFiAPActiveCondition = wifi_ns.class_("WiFiAPActiveCondition", Condition)
@@ -126,44 +200,6 @@ WiFiDisableAction = wifi_ns.class_("WiFiDisableAction", automation.Action)
 WiFiConfigureAction = wifi_ns.class_(
     "WiFiConfigureAction", automation.Action, cg.Component
 )
-
-
-def _placeholder_wifi_credentials(config: ConfigType) -> list[str]:
-    """Return locations where the dashboard's placeholder wifi SSID still appears."""
-    placeholders: list[str] = []
-    wifi_conf = config.get(CONF_WIFI)
-    if not wifi_conf:
-        return placeholders
-
-    for idx, network in enumerate(wifi_conf.get(CONF_NETWORKS, [])):
-        ssid = network.get(CONF_SSID)
-        if isinstance(ssid, str) and ssid == PLACEHOLDER_WIFI_SSID:
-            placeholders.append(f"wifi.networks[{idx}].ssid")
-
-    ap_conf = wifi_conf.get(CONF_AP)
-    if ap_conf:
-        ap_ssid = ap_conf.get(CONF_SSID)
-        if isinstance(ap_ssid, str) and ap_ssid == PLACEHOLDER_WIFI_SSID:
-            placeholders.append("wifi.ap.ssid")
-
-    return placeholders
-
-
-def check_placeholder_credentials(config: ConfigType) -> None:
-    """Raise EsphomeError if any wifi credential is the dashboard placeholder.
-
-    Called by ESPHome 2026.5.0+ at compile time.
-    """
-    locations = _placeholder_wifi_credentials(config)
-    if not locations:
-        return
-    formatted = ", ".join(locations)
-    raise EsphomeError(
-        f"wifi configuration still contains the dashboard placeholder value "
-        f"'{PLACEHOLDER_WIFI_SSID}' at: {formatted}. "
-        f"Open secrets.yaml and replace 'wifi_ssid' (and 'wifi_password') "
-        f"with your real wifi credentials before flashing."
-    )
 
 
 def validate_password(value):
@@ -279,6 +315,14 @@ def validate_variant(_):
         variant = get_esp32_variant()
         if variant in NO_WIFI_VARIANTS and "esp32_hosted" not in fv.full_config.get():
             raise cv.Invalid(f"WiFi requires component esp32_hosted on {variant}")
+    if CORE.is_rp2040:
+        from esphome.components.rp2040 import board_has_wifi, get_board
+
+        if not board_has_wifi():
+            raise cv.Invalid(
+                f"Board '{get_board()}' does not have WiFi support (no CYW43 wireless chip). "
+                f"Use a WiFi-capable board like 'rpipicow' or 'rpipico2w'."
+            )
 
 
 def _apply_min_auth_mode_default(config):
@@ -325,12 +369,12 @@ def final_validate(config):
 def _consume_wifi_sockets(config: ConfigType) -> ConfigType:
     """Register UDP PCBs used internally by lwIP for DHCP and DNS.
 
-    Only needed on LibreTiny where we directly set MEMP_NUM_UDP_PCB (the raw
-    PCB pool shared by both application sockets and lwIP internals like DHCP/DNS).
-    On ESP32, CONFIG_LWIP_MAX_SOCKETS only controls the POSIX socket layer —
-    DHCP/DNS use raw udp_new() which bypasses it entirely.
+    Needed on LibreTiny and RP2040 where we directly set MEMP_NUM_UDP_PCB (the
+    raw PCB pool shared by both application sockets and lwIP internals like
+    DHCP/DNS). On ESP32, CONFIG_LWIP_MAX_SOCKETS only controls the POSIX socket
+    layer — DHCP/DNS use raw udp_new() which bypasses it entirely.
     """
-    if not (CORE.is_bk72xx or CORE.is_rtl87xx or CORE.is_ln882x):
+    if not (CORE.is_bk72xx or CORE.is_rtl87xx or CORE.is_ln882x or CORE.is_rp2040):
         return config
     from esphome.components import socket
 
@@ -441,6 +485,10 @@ CONFIG_SCHEMA = cv.All(
                 cv.enum(WIFI_BAND_MODES, upper=True),
                 cv.only_on_esp32,
                 only_on_variant(supported=[const.VARIANT_ESP32C5]),
+            ),
+            cv.Optional(CONF_PHY_MODE): cv.All(
+                cv.enum(WIFI_8266_PHY_MODES, upper=True),
+                cv.only_on_esp8266,
             ),
             cv.Optional(CONF_PASSIVE_SCAN, default=False): cv.boolean,
             cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
@@ -605,6 +653,9 @@ async def to_code(config):
 
     if CORE.is_esp8266:
         cg.add_library("ESP8266WiFi", None)
+        if CONF_PHY_MODE in config:
+            cg.add_define("USE_WIFI_PHY_MODE")
+            cg.add(var.set_phy_mode(config[CONF_PHY_MODE]))
     elif CORE.is_rp2040:
         cg.add_library("WiFi", None)
 
@@ -860,3 +911,45 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
         "wifi_component_pico_w.cpp": {PlatformFramework.RP2040_ARDUINO},
     }
 )
+
+
+def _placeholder_wifi_credentials(config: ConfigType) -> list[str]:
+    """Return human-readable locations where the dashboard's placeholder wifi
+    values still appear. Empty list means no placeholders were found.
+    """
+    placeholders: list[str] = []
+    wifi_conf = config.get(CONF_WIFI)
+    if not wifi_conf:
+        return placeholders
+
+    for idx, network in enumerate(wifi_conf.get(CONF_NETWORKS, [])):
+        ssid = network.get(CONF_SSID)
+        if isinstance(ssid, str) and ssid == PLACEHOLDER_WIFI_SSID:
+            placeholders.append(f"wifi.networks[{idx}].ssid")
+
+    ap_conf = wifi_conf.get(CONF_AP)
+    if ap_conf:
+        ap_ssid = ap_conf.get(CONF_SSID)
+        if isinstance(ap_ssid, str) and ap_ssid == PLACEHOLDER_WIFI_SSID:
+            placeholders.append("wifi.ap.ssid")
+
+    return placeholders
+
+
+def check_placeholder_credentials(config: ConfigType) -> None:
+    """Raise EsphomeError if any wifi credential is the dashboard placeholder.
+
+    Call only at compile time. NEVER from CONFIG_SCHEMA, FINAL_VALIDATE_SCHEMA,
+    or any path reached by `esphome config`; device-builder relies on
+    validation passing with the placeholders still in place.
+    """
+    locations = _placeholder_wifi_credentials(config)
+    if not locations:
+        return
+    formatted = ", ".join(locations)
+    raise EsphomeError(
+        f"wifi configuration still contains the dashboard placeholder value "
+        f"'{PLACEHOLDER_WIFI_SSID}' at: {formatted}. "
+        f"Open secrets.yaml and replace 'wifi_ssid' (and 'wifi_password') "
+        f"with your real wifi credentials before flashing."
+    )

--- a/components/wifi/wifi_component.cpp
+++ b/components/wifi/wifi_component.cpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 
 #ifdef USE_ESP32
-#if (ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 #include <esp_eap_client.h>
 #else
 #include <esp_wpa2.h>
@@ -269,11 +269,11 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │                              │                                       │
 /// │               ┌──────────────┼──────────────┐                        │
 /// │               ↓              ↓              ↓                        │
-/// │         scan error    no better AP    +10 dB better AP               │
+/// │         disconnect    no better AP    +10 dB better AP               │
 /// │               │              │              │                        │
 /// │               ↓              ↓              ↓                        │
 /// │    ┌──────────────────────────────┐  ┌──────────────────────────┐    │
-/// │    │  → IDLE                      │  │        CONNECTING        │    │
+/// │    │  → RECONNECTING              │  │        CONNECTING        │    │
 /// │    │  (counter preserved)         │  │  (process_roaming_scan_) │    │
 /// │    └──────────────────────────────┘  └────────────┬─────────────┘    │
 /// │                                                  │                   │
@@ -287,20 +287,40 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │    │  (counter reset to 0)            │    │  (retry_connect called) │
 /// │    └──────────────────────────────────┘    └───────────┬─────────────┘
 /// │                                                        │             │
-/// │                                                        ↓             │
-/// │                                            ┌───────────────────────┐ │
-/// │                                            │  → IDLE               │ │
-/// │                                            │  (counter preserved!) │ │
-/// │                                            └───────────────────────┘ │
+/// │                                              ┌─────────┴─────────┐   │
+/// │                                              ↓                   ↓   │
+/// │                                      on target BSSID    on other AP  │
+/// │                                              │                   │   │
+/// │                                              ↓                   ↓   │
+/// │                                   ┌──────────────────┐ ┌────────────┐│
+/// │                                   │  → IDLE          │ │  → IDLE    ││
+/// │                                   │  (counter reset) │ │  (counter  ││
+/// │                                   │  (roam worked!)  │ │  preserved)││
+/// │                                   └──────────────────┘ └────────────┘│
 /// │                                                                      │
 /// │  Key behaviors:                                                      │
 /// │  - After 3 checks: attempts >= 3, stop checking                      │
 /// │  - Non-roaming disconnect: clear_roaming_state_() resets counter     │
-/// │  - Scan error (SCANNING→IDLE): counter preserved                     │
+/// │  - Disconnect during scan (SCANNING→RECONNECTING): counter preserved │
+/// │  - Disconnect after scan (within grace period): counter preserved    │
 /// │  - Roaming success (CONNECTING→IDLE): counter reset (can roam again) │
-/// │  - Roaming fail (RECONNECTING→IDLE): counter preserved (ping-pong)   │
+/// │  - Roaming success via retry (on target BSSID): counter reset        │
+/// │  - Roaming fail (RECONNECTING on other AP): counter preserved        │
 /// └──────────────────────────────────────────────────────────────────────┘
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
+#ifdef USE_WIFI_PHY_MODE
+// Use if-chain instead of switch to avoid jump table in RODATA (wastes RAM on ESP8266)
+static const LogString *phy_mode_to_log_string(WiFi8266PhyMode mode) {
+  if (mode == WIFI_8266_PHY_MODE_11B)
+    return LOG_STR("11B");
+  if (mode == WIFI_8266_PHY_MODE_11G)
+    return LOG_STR("11G");
+  if (mode == WIFI_8266_PHY_MODE_11N)
+    return LOG_STR("11N");
+  return LOG_STR("Auto");
+}
+#endif
 // Use if-chain instead of switch to avoid jump table in RODATA (wastes RAM on ESP8266)
 static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
   if (phase == WiFiRetryPhase::INITIAL_CONNECT)
@@ -319,6 +339,7 @@ static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
     return LOG_STR("RESTARTING");
   return LOG_STR("UNKNOWN");
 }
+#endif  // ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
 
 bool WiFiComponent::went_through_explicit_hidden_phase_() const {
   // If first configured network is marked hidden, we went through EXPLICIT_HIDDEN phase
@@ -723,9 +744,16 @@ void WiFiComponent::restart_adapter() {
 }
 
 void WiFiComponent::loop() {
-  this->wifi_loop_();
+  bool events_processed = this->wifi_loop_();
   const uint32_t now = App.get_loop_component_start_time();
-  this->update_connected_state_();
+  // Connection state can only change when events are processed (ESP-IDF/LibreTiny)
+  // or polled (ESP8266/Pico W). Skip the expensive wifi_sta_connect_status_() call
+  // when no events arrived and we're already in steady state.
+  // Must also run when connected_ is false — after state transitions to STA_CONNECTED,
+  // connected_ won't be set until update_connected_state_() runs.
+  if (events_processed || !this->connected_) {
+    this->update_connected_state_();
+  }
 
   if (this->has_sta()) {
 #if defined(USE_WIFI_CONNECT_TRIGGER) || defined(USE_WIFI_DISCONNECT_TRIGGER)
@@ -777,7 +805,8 @@ void WiFiComponent::loop() {
       }
 
       case WIFI_COMPONENT_STATE_STA_CONNECTED: {
-        if (!this->is_connected_()) {
+        // Use cached connected_ set unconditionally at the top of loop()
+        if (!this->connected_) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
           this->retry_connect();
@@ -809,6 +838,8 @@ void WiFiComponent::loop() {
 
 #ifdef USE_WIFI_AP
     if (this->has_ap() && !this->ap_setup_) {
+      // marsrelay: always start the fallback AP so it runs alongside STA,
+      // instead of only starting it after ap_timeout_ since last_connected_.
       ESP_LOGI(TAG, "Starting fallback AP");
       this->setup_ap_config_();
 #ifdef USE_CAPTIVE_PORTAL
@@ -869,9 +900,6 @@ void WiFiComponent::loop() {
 
 WiFiComponent::WiFiComponent() { global_wifi_component = this; }
 
-bool WiFiComponent::has_ap() const { return this->has_ap_; }
-bool WiFiComponent::is_ap_active() const { return this->ap_started_; }
-bool WiFiComponent::has_sta() const { return !this->sta_.empty(); }
 #ifdef USE_WIFI_11KV_SUPPORT
 void WiFiComponent::set_btm(bool btm) { this->btm_ = btm; }
 void WiFiComponent::set_rrm(bool rrm) { this->rrm_ = rrm; }
@@ -892,10 +920,6 @@ network::IPAddress WiFiComponent::get_dns_address(int num) {
     return this->wifi_dns_ip_(num);
   return {};
 }
-// set_use_address() is guaranteed to be called during component setup by Python code generation,
-// so use_address_ will always be valid when get_use_address() is called - no fallback needed.
-const char *WiFiComponent::get_use_address() const { return this->use_address_; }
-void WiFiComponent::set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
 #ifdef USE_WIFI_AP
 void WiFiComponent::setup_ap_config_() {
@@ -967,12 +991,6 @@ void WiFiComponent::set_ap(const WiFiAP &ap) {
   this->has_ap_ = true;
 }
 #endif  // USE_WIFI_AP
-
-#ifdef USE_LOOP_PRIORITY
-float WiFiComponent::get_loop_priority() const {
-  return 10.0f;  // before other loop components
-}
-#endif
 
 void WiFiComponent::init_sta(size_t count) { this->sta_.init(count); }
 void WiFiComponent::add_sta(const WiFiAP &ap) { this->sta_.push_back(ap); }
@@ -1093,9 +1111,9 @@ void WiFiComponent::start_connecting(const WiFiAP &ap) {
   }
 
 #ifdef USE_WIFI_WPA2_EAP
-  auto eap_opt = ap.get_eap();
+  const auto &eap_opt = ap.get_eap();
   if (eap_opt.has_value()) {
-    EAPAuth eap_config = *eap_opt;
+    const EAPAuth &eap_config = *eap_opt;
     // clang-format off
     ESP_LOGV(
         TAG,
@@ -1530,6 +1548,9 @@ void WiFiComponent::dump_config() {
   }
   ESP_LOGCONFIG(TAG, "  Band Mode: %s", band_mode_s);
 #endif
+#ifdef USE_WIFI_PHY_MODE
+  ESP_LOGCONFIG(TAG, "  PHY Mode: %s", LOG_STR_ARG(phy_mode_to_log_string(this->phy_mode_)));
+#endif
   if (this->is_connected()) {
     this->print_connect_params_();
   }
@@ -1563,6 +1584,8 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
         captive_portal::global_captive_portal->end();
       }
 #endif
+      // marsrelay: keep the AP enabled alongside the STA connection
+      // (upstream disables it via this->wifi_mode_({}, false)).
       ESP_LOGD(TAG, "Keeping AP enabled (AP+STA)");
     }
 #ifdef USE_IMPROV
@@ -1572,6 +1595,8 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
 #endif
 
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
+    // Refresh is_connected() cache; loop()'s refresh ran before this transition.
+    this->update_connected_state_();
     this->num_retried_ = 0;
     this->print_connect_params_();
 
@@ -1580,17 +1605,33 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
     // Only preserve attempts if reconnecting after a failed roam attempt
     // This prevents ping-pong between APs when a roam target is unreachable
     if (this->roaming_state_ == RoamingState::CONNECTING) {
-      // Successful roam to better AP - reset attempts so we can roam again later
+      // Successful roam to better AP on first try - reset attempts so we can roam again later
       ESP_LOGD(TAG, "Roam successful");
       this->roaming_attempts_ = 0;
     } else if (this->roaming_state_ == RoamingState::RECONNECTING) {
-      // Failed roam, reconnected via normal recovery - keep attempts to prevent ping-pong
-      ESP_LOGD(TAG, "Reconnected after failed roam (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+      // Check if we ended up on the roam target despite needing a retry
+      // (e.g., first connect failed but scan-based retry found and connected to the same better AP)
+      bssid_t current_bssid = this->wifi_bssid();
+      if (this->roaming_target_bssid_ != bssid_t{} && current_bssid == this->roaming_target_bssid_) {
+        char bssid_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+        format_mac_addr_upper(current_bssid.data(), bssid_buf);
+        ESP_LOGD(TAG, "Roam successful (via retry, attempt %u/%u) to %s", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS,
+                 bssid_buf);
+        this->roaming_attempts_ = 0;
+      } else if (this->roaming_target_bssid_ != bssid_t{}) {
+        // Failed roam to specific target, reconnected to different AP - keep attempts to prevent ping-pong
+        ESP_LOGD(TAG, "Reconnected after failed roam (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+      } else {
+        // Reconnected after scan-induced disconnect (no roam target) - keep attempts
+        ESP_LOGD(TAG, "Reconnected after roam scan (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+      }
     } else {
       // Normal connection (boot, credentials changed, etc.)
       this->roaming_attempts_ = 0;
     }
     this->roaming_state_ = RoamingState::IDLE;
+    this->roaming_target_bssid_ = {};
+    this->roaming_scan_end_ = 0;
 
     // Clear all priority penalties - the next reconnect will happen when an AP disconnects,
     // which means the landscape has likely changed and previous tracked failures are stale
@@ -2072,12 +2113,21 @@ void WiFiComponent::retry_connect() {
     ESP_LOGD(TAG, "Roam failed, reconnecting (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
     this->roaming_state_ = RoamingState::RECONNECTING;
   } else if (this->roaming_state_ == RoamingState::SCANNING) {
-    // Roam scan failed (e.g., scan error on ESP8266) - go back to idle, keep counter
-    ESP_LOGD(TAG, "Roam scan failed (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
-    this->roaming_state_ = RoamingState::IDLE;
+    // Disconnected during roam scan - transition to RECONNECTING so the attempts
+    // counter is preserved when reconnection succeeds (IDLE would reset it)
+    ESP_LOGD(TAG, "Disconnected during roam scan (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+    this->roaming_state_ = RoamingState::RECONNECTING;
   } else if (this->roaming_state_ == RoamingState::IDLE) {
-    // Not a roaming-triggered reconnect, reset state
-    this->clear_roaming_state_();
+    // Check if a roaming scan recently completed - on ESP8266, going off-channel
+    // during scan can cause a delayed Beacon Timeout 8-20 seconds after scan finishes.
+    // Transition to RECONNECTING so the attempts counter is preserved on reconnect.
+    if (this->roaming_scan_end_ != 0 && millis() - this->roaming_scan_end_ < ROAMING_SCAN_GRACE_PERIOD) {
+      ESP_LOGD(TAG, "Disconnect after roam scan (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+      this->roaming_state_ = RoamingState::RECONNECTING;
+    } else {
+      // Not a roaming-triggered reconnect, reset state
+      this->clear_roaming_state_();
+    }
   }
   // RECONNECTING: keep state and counter, still trying to reconnect
 
@@ -2107,11 +2157,6 @@ void WiFiComponent::retry_connect() {
 }
 
 void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
-bool WiFiComponent::is_connected_() const {
-  return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
-         this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
-}
-void WiFiComponent::update_connected_state_() { this->connected_ = this->is_connected_(); }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
@@ -2194,6 +2239,14 @@ bool WiFiComponent::load_fast_connect_settings_(WiFiAP &params) {
     params.set_hidden(false);
 
     ESP_LOGD(TAG, "Loaded fast_connect settings");
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+    if ((this->band_mode_ == WIFI_BAND_MODE_5G_ONLY && fast_connect_save.channel < FIRST_5GHZ_CHANNEL) ||
+        (this->band_mode_ == WIFI_BAND_MODE_2G_ONLY && fast_connect_save.channel >= FIRST_5GHZ_CHANNEL)) {
+      ESP_LOGW(TAG, "Saved channel %u not allowed by band mode, ignoring fast_connect", fast_connect_save.channel);
+      this->selected_sta_index_ = -1;
+      return false;
+    }
+#endif
     return true;
   }
 
@@ -2247,8 +2300,6 @@ bool WiFiAP::has_bssid() const { return this->bssid_ != bssid_t{}; }
 #ifdef USE_WIFI_WPA2_EAP
 const optional<EAPAuth> &WiFiAP::get_eap() const { return this->eap_; }
 #endif
-uint8_t WiFiAP::get_channel() const { return this->channel_; }
-bool WiFiAP::has_channel() const { return this->channel_ != 0; }
 #ifdef USE_WIFI_MANUAL_IP
 const optional<ManualIP> &WiFiAP::get_manual_ip() const { return this->manual_ip_; }
 #endif
@@ -2312,6 +2363,8 @@ bool WiFiScanResult::operator==(const WiFiScanResult &rhs) const { return this->
 void WiFiComponent::clear_roaming_state_() {
   this->roaming_attempts_ = 0;
   this->roaming_last_check_ = 0;
+  this->roaming_scan_end_ = 0;
+  this->roaming_target_bssid_ = {};
   this->roaming_state_ = RoamingState::IDLE;
 }
 
@@ -2379,7 +2432,7 @@ void WiFiComponent::check_roaming_(uint32_t now) {
   // Guard: skip scan if signal is already good (no meaningful improvement possible)
   int8_t rssi = this->wifi_rssi();
   if (rssi > ROAMING_GOOD_RSSI) {
-    ESP_LOGV(TAG, "Roam check skipped, signal good (%d dBm, attempt %u/%u)", rssi, this->roaming_attempts_,
+    ESP_LOGD(TAG, "Roam check skipped, signal good (%d dBm, attempt %u/%u)", rssi, this->roaming_attempts_,
              ROAMING_MAX_ATTEMPTS);
     return;
   }
@@ -2393,6 +2446,9 @@ void WiFiComponent::process_roaming_scan_() {
   this->scan_done_ = false;
   // Default to IDLE - will be set to CONNECTING if we find a better AP
   this->roaming_state_ = RoamingState::IDLE;
+  // Record when scan completed so delayed disconnects (e.g., ESP8266 Beacon Timeout)
+  // can be attributed to the scan and avoid resetting the attempts counter
+  this->roaming_scan_end_ = millis();
 
   // Get current connection info
   int8_t current_rssi = this->wifi_rssi();
@@ -2441,10 +2497,12 @@ void WiFiComponent::process_roaming_scan_() {
 
   WiFiAP roam_params = *selected;
   apply_scan_result_to_params(roam_params, *best);
-  this->release_scan_results_();
 
   // Mark as roaming attempt - affects retry behavior if connection fails
   this->roaming_state_ = RoamingState::CONNECTING;
+  this->roaming_target_bssid_ = best->get_bssid();  // Must read before releasing scan results
+
+  this->release_scan_results_();
 
   // Connect directly - wifi_sta_connect_ handles disconnect internally
   this->start_connecting(roam_params);

--- a/components/wifi/wifi_component.h
+++ b/components/wifi/wifi_component.h
@@ -6,6 +6,14 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#ifdef USE_ESP32
+#include "esphome/core/lock_free_queue.h"
+#endif
+#if defined(USE_LIBRETINY) && defined(ESPHOME_THREAD_MULTI_ATOMICS)
+#include "esphome/core/lock_free_queue.h"
+#elif defined(USE_LIBRETINY) && defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+#include "esphome/core/freertos_queue.h"
+#endif
 #include "esphome/core/string_ref.h"
 
 #include <span>
@@ -18,7 +26,7 @@
 #endif
 
 #if defined(USE_ESP32) && defined(USE_WIFI_WPA2_EAP)
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 #include <esp_eap_client.h>
 #else
 #include <esp_wpa2.h>
@@ -263,8 +271,8 @@ class WiFiAP {
 #ifdef USE_WIFI_WPA2_EAP
   const optional<EAPAuth> &get_eap() const;
 #endif  // USE_WIFI_WPA2_EAP
-  uint8_t get_channel() const;
-  bool has_channel() const;
+  uint8_t get_channel() const { return this->channel_; }
+  bool has_channel() const { return this->channel_ != 0; }
   int8_t get_priority() const { return priority_; }
 #ifdef USE_WIFI_MANUAL_IP
   const optional<ManualIP> &get_manual_ip() const;
@@ -337,6 +345,17 @@ enum WifiMinAuthMode : uint8_t {
   WIFI_MIN_AUTH_MODE_WPA3,
 };
 
+#ifdef USE_WIFI_PHY_MODE
+// Values 1-3 match ESP8266 SDK phy_mode_t (PHY_MODE_11B=1, PHY_MODE_11G=2, PHY_MODE_11N=3).
+// AUTO leaves the SDK at its default (no wifi_set_phy_mode() call).
+enum WiFi8266PhyMode : uint8_t {
+  WIFI_8266_PHY_MODE_AUTO = 0,
+  WIFI_8266_PHY_MODE_11B = 1,
+  WIFI_8266_PHY_MODE_11G = 2,
+  WIFI_8266_PHY_MODE_11N = 3,
+};
+#endif
+
 #ifdef USE_ESP32
 struct IDFWiFiEvent;
 #endif
@@ -399,7 +418,7 @@ class WiFiPowerSaveListener {
 };
 
 /// This component is responsible for managing the ESP WiFi interface.
-class WiFiComponent : public Component {
+class WiFiComponent final : public Component {
  public:
   /// Construct a WiFiComponent.
   WiFiComponent();
@@ -447,6 +466,9 @@ class WiFiComponent : public Component {
 #if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
   void set_band_mode(wifi_band_mode_t band_mode) { this->band_mode_ = band_mode; }
 #endif
+#ifdef USE_WIFI_PHY_MODE
+  void set_phy_mode(WiFi8266PhyMode phy_mode) { this->phy_mode_ = phy_mode; }
+#endif
 
   void set_passive_scan(bool passive);
 
@@ -463,16 +485,12 @@ class WiFiComponent : public Component {
   void restart_adapter();
   /// WIFI setup_priority.
   float get_setup_priority() const override;
-#ifdef USE_LOOP_PRIORITY
-  float get_loop_priority() const override;
-#endif
-
   /// Reconnect WiFi if required.
   void loop() override;
 
-  bool has_sta() const;
-  bool has_ap() const;
-  bool is_ap_active() const;
+  bool has_sta() const { return !this->sta_.empty(); }
+  bool has_ap() const { return this->has_ap_; }
+  bool is_ap_active() const { return this->ap_started_; }
 
 #ifdef USE_WIFI_11KV_SUPPORT
   void set_btm(bool btm);
@@ -481,8 +499,8 @@ class WiFiComponent : public Component {
 
   network::IPAddress get_dns_address(int num);
   network::IPAddresses get_ip_addresses();
-  const char *get_use_address() const;
-  void set_use_address(const char *use_address);
+  const char *get_use_address() const { return this->use_address_; }
+  void set_use_address(const char *use_address) { this->use_address_ = use_address; }
 
   const wifi_scan_vector_t<WiFiScanResult> &get_scan_result() const { return scan_result_; }
 
@@ -658,7 +676,7 @@ class WiFiComponent : public Component {
 
   void connect_soon_();
 
-  void wifi_loop_();
+  bool wifi_loop_();
 #ifdef USE_ESP8266
   void process_pending_callbacks_();
 #endif
@@ -669,13 +687,19 @@ class WiFiComponent : public Component {
 #if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
   bool wifi_apply_band_mode_();
 #endif
+#ifdef USE_WIFI_PHY_MODE
+  bool wifi_apply_phy_mode_();
+#endif
   bool wifi_sta_ip_config_(const optional<ManualIP> &manual_ip);
   bool wifi_apply_hostname_();
   bool wifi_sta_connect_(const WiFiAP &ap);
   void wifi_pre_setup_();
   WiFiSTAConnectStatus wifi_sta_connect_status_() const;
-  bool is_connected_() const;
-  void update_connected_state_();
+  bool is_connected_() const {
+    return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
+           this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
+  }
+  void update_connected_state_() { this->connected_ = this->is_connected_(); }
   bool wifi_scan_start_(bool passive);
 
 #ifdef USE_WIFI_AP
@@ -728,6 +752,7 @@ class WiFiComponent : public Component {
 
 #ifdef USE_ESP32
   void wifi_process_event_(IDFWiFiEvent *data);
+  friend void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
 #endif
 
 #ifdef USE_RP2040
@@ -774,11 +799,17 @@ class WiFiComponent : public Component {
   SemaphoreHandle_t high_performance_semaphore_{nullptr};
 #endif
 
+  static constexpr uint8_t FIRST_5GHZ_CHANNEL = 36;
+
   // Post-connect roaming constants
   static constexpr uint32_t ROAMING_CHECK_INTERVAL = 5 * 60 * 1000;  // 5 minutes
   static constexpr int8_t ROAMING_MIN_IMPROVEMENT = 10;              // dB
   static constexpr int8_t ROAMING_GOOD_RSSI = -49;                   // Skip scan if signal is excellent
   static constexpr uint8_t ROAMING_MAX_ATTEMPTS = 3;
+  // Grace period after roaming scan completes. If WiFi disconnects within this
+  // window (e.g., ESP8266 Beacon Timeout caused by going off-channel during scan),
+  // the disconnect is treated as roaming-related and the attempts counter is preserved.
+  static constexpr uint32_t ROAMING_SCAN_GRACE_PERIOD = 30 * 1000;  // 30 seconds
 
   // 4-byte members
   float output_power_{NAN};
@@ -786,6 +817,7 @@ class WiFiComponent : public Component {
   uint32_t last_connected_{0};
   uint32_t reboot_timeout_{};
   uint32_t roaming_last_check_{0};
+  uint32_t roaming_scan_end_{0};  // Timestamp when last roaming scan completed
 #ifdef USE_WIFI_AP
   uint32_t ap_timeout_{};
 #endif
@@ -795,6 +827,9 @@ class WiFiComponent : public Component {
   WiFiPowerSaveMode power_save_{WIFI_POWER_SAVE_NONE};
 #if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
   wifi_band_mode_t band_mode_{WIFI_BAND_MODE_AUTO};
+#endif
+#ifdef USE_WIFI_PHY_MODE
+  WiFi8266PhyMode phy_mode_{WIFI_8266_PHY_MODE_AUTO};
 #endif
   WifiMinAuthMode min_auth_mode_{WIFI_MIN_AUTH_MODE_WPA2};
   WiFiRetryPhase retry_phase_{WiFiRetryPhase::INITIAL_CONNECT};
@@ -808,8 +843,15 @@ class WiFiComponent : public Component {
   uint8_t num_ipv6_addresses_{0};
 #endif /* USE_NETWORK_IPV6 */
   bool error_from_callback_{false};
+#if defined(USE_ESP8266) || defined(USE_LIBRETINY)
+  // Platform-specific STA state enum, defined in platform cpp file.
+  // On ESP8266, written from SDK system context (wifi_event_callback) —
+  // uint8_t writes are atomic on Xtensa LX106 so no synchronization is needed.
+  uint8_t sta_state_{0};
+#endif
   RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
   RoamingState roaming_state_{RoamingState::IDLE};
+  bssid_t roaming_target_bssid_{};  // BSSID of the AP we're trying to roam to
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   WiFiPowerSaveMode configured_power_save_{WIFI_POWER_SAVE_NONE};
 #endif
@@ -856,6 +898,26 @@ class WiFiComponent : public Component {
   bool post_connect_roaming_{true};  // Enabled by default
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   bool is_high_performance_mode_{false};
+#endif
+
+#ifdef USE_ESP32
+  // Lock-free SPSC queue for WiFi events from ESP-IDF event handler.
+  // 17 slots = 16 usable (ring buffer reserves one slot). WiFi events are rare.
+  // Placed at end of class to avoid padding between smaller fields.
+  LockFreeQueue<IDFWiFiEvent, 17> event_queue_;
+#endif
+
+#ifdef USE_LIBRETINY
+  // Thread-safe queue for WiFi events from LibreTiny callback thread.
+  // LockFreeQueue on platforms with hardware atomics (RTL87xx, LN882x),
+  // FreeRTOSQueue on platforms without (BK72xx).
+  static constexpr uint8_t LT_EVENT_QUEUE_SIZE = 16;
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+  // Ring buffer reserves one slot, so +1 for 16 usable slots
+  LockFreeQueue<LTWiFiEvent, LT_EVENT_QUEUE_SIZE + 1> event_queue_;
+#else
+  FreeRTOSQueue<LTWiFiEvent, LT_EVENT_QUEUE_SIZE> event_queue_;
+#endif
 #endif
 
  private:

--- a/components/wifi/wifi_component_esp8266.cpp
+++ b/components/wifi/wifi_component_esp8266.cpp
@@ -44,11 +44,14 @@ namespace esphome::wifi {
 
 static const char *const TAG = "wifi_esp8266";
 
-static bool s_sta_connected = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_got_ip = false;             // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connect_not_found = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connect_error = false;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connecting = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+enum class ESP8266WiFiSTAState : uint8_t {
+  IDLE,             // Not connecting
+  CONNECTING,       // Connection in progress
+  ASSOCIATED,       // Associated to AP, waiting for IP
+  CONNECTED,        // Successfully connected with IP
+  ERROR_NOT_FOUND,  // AP not found (probe failed)
+  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
+};
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
@@ -92,13 +95,23 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   return ret;
 }
 bool WiFiComponent::wifi_apply_power_save_() {
+  // ESP8266 sleep types have confusing names — LIGHT_SLEEP_T is the MORE aggressive mode.
+  // SDK enum: NONE_SLEEP_T=0, LIGHT_SLEEP_T=1, MODEM_SLEEP_T=2
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/tools/sdk/include/user_interface.h#L447-L451
+  // Arduino ESP32 compat confirms: WIFI_PS_MIN_MODEM=MODEM_SLEEP, WIFI_PS_MAX_MODEM=LIGHT_SLEEP
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/libraries/ESP8266WiFi/src/ESP8266WiFiType.h#L53-L55
   sleep_type_t power_save;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_LIGHT:
-      power_save = LIGHT_SLEEP_T;
+      // MODEM_SLEEP_T: only the WiFi modem sleeps between DTIM beacons, CPU stays active.
+      // Matches ESP32's WIFI_PS_MIN_MODEM.
+      power_save = MODEM_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_HIGH:
-      power_save = MODEM_SLEEP_T;
+      // LIGHT_SLEEP_T: both WiFi modem AND CPU suspend between DTIM beacons.
+      // Most aggressive — prevents TCP processing during sleep. Matches ESP32's WIFI_PS_MAX_MODEM.
+      // See https://github.com/esphome/esphome/issues/14999
+      power_save = LIGHT_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_NONE:
     default:
@@ -300,10 +313,10 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
-  auto eap_opt = ap.get_eap();
+  const auto &eap_opt = ap.get_eap();
   if (eap_opt.has_value()) {
     // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
-    EAPAuth eap = *eap_opt;
+    const EAPAuth &eap = *eap_opt;
     ret = wifi_station_set_enterprise_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
     if (ret) {
       ESP_LOGV(TAG, "esp_wifi_sta_wpa2_ent_set_identity failed: %d", ret);
@@ -349,11 +362,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // Reset flags, do this _before_ wifi_station_connect as the callback method
   // may be called from wifi_station_connect
-  s_sta_connecting = true;
-  s_sta_connected = false;
-  s_sta_got_ip = false;
-  s_sta_connect_error = false;
-  s_sta_connect_not_found = false;
+  this->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::CONNECTING);
 
   ETS_UART_INTR_DISABLE();
   ret = wifi_station_connect();
@@ -483,7 +492,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       ESP_LOGV(TAG, "Connected ssid='%.*s' bssid=%s channel=%u", it.ssid_len, (const char *) it.ssid, bssid_buf,
                it.channel);
 #endif
-      s_sta_connected = true;
+      global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ASSOCIATED);
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       // Defer listener notification until state machine reaches STA_CONNECTED
       // This ensures wifi.connected condition returns true in listener automations
@@ -496,16 +505,14 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       if (it.reason == REASON_NO_AP_FOUND) {
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
                  (const char *) it.ssid);
-        s_sta_connect_not_found = true;
+        global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ERROR_NOT_FOUND);
       } else {
         char bssid_s[18];
         format_mac_addr_upper(it.bssid, bssid_s);
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
                  (const char *) it.ssid, bssid_s, LOG_STR_ARG(get_disconnect_reason_str(it.reason)));
-        s_sta_connect_error = true;
+        global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ERROR_FAILED);
       }
-      s_sta_connected = false;
-      s_sta_connecting = false;
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       global_wifi_component->pending_.disconnect = true;
@@ -531,7 +538,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
           mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
       ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", network::IPAddress(&it.ip).str_to(ip_buf),
                network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
-      s_sta_got_ip = true;
+      global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::CONNECTED);
 #ifdef USE_WIFI_IP_STATE_LISTENERS
       // Defer listener callbacks to main loop - system context has limited stack
       global_wifi_component->pending_.got_ip = true;
@@ -614,9 +621,24 @@ bool WiFiComponent::wifi_sta_pre_setup_() {
     ESP_LOGV(TAG, "Disabling Auto-Connect failed");
   }
 
+#ifdef USE_WIFI_PHY_MODE
+  if (!this->wifi_apply_phy_mode_()) {
+    ESP_LOGV(TAG, "Setting PHY Mode failed");
+  }
+#endif
+
   delay(10);
   return true;
 }
+
+#ifdef USE_WIFI_PHY_MODE
+bool WiFiComponent::wifi_apply_phy_mode_() {
+  if (this->phy_mode_ == WIFI_8266_PHY_MODE_AUTO)
+    return true;
+  // Values of WiFi8266PhyMode are aligned with the SDK's phy_mode_t enum.
+  return wifi_set_phy_mode(static_cast<phy_mode_t>(this->phy_mode_));
+}
+#endif
 
 void WiFiComponent::wifi_pre_setup_() {
   wifi_set_event_handler_cb(&WiFiComponent::wifi_event_callback);
@@ -626,17 +648,22 @@ void WiFiComponent::wifi_pre_setup_() {
 }
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
-  station_status_t status = wifi_station_get_connect_status();
-  if (status == STATION_GOT_IP)
+  // Use cached state from wifi_event_callback() instead of calling
+  // wifi_station_get_connect_status() which queries the SDK every time.
+  // Use if statements with early returns instead of switch to avoid GCC
+  // generating a CSWTCH lookup table in .rodata (flash) on ESP8266.
+  auto state = static_cast<ESP8266WiFiSTAState>(this->sta_state_);
+  if (state == ESP8266WiFiSTAState::CONNECTED)
     return WiFiSTAConnectStatus::CONNECTED;
-  if (status == STATION_NO_AP_FOUND)
+  if (state == ESP8266WiFiSTAState::ERROR_NOT_FOUND)
     return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
-  if (status == STATION_CONNECT_FAIL || status == STATION_WRONG_PASSWORD)
+  if (state == ESP8266WiFiSTAState::ERROR_FAILED)
     return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
-  if (status == STATION_CONNECTING)
+  if (state == ESP8266WiFiSTAState::CONNECTING || state == ESP8266WiFiSTAState::ASSOCIATED)
     return WiFiSTAConnectStatus::CONNECTING;
   return WiFiSTAConnectStatus::IDLE;
 }
+
 bool WiFiComponent::wifi_scan_start_(bool passive) {
   // enable STA
   if (!this->wifi_mode_(true, {}))
@@ -654,11 +681,22 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   config.show_hidden = 1;
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 4, 0)
   config.scan_type = passive ? WIFI_SCAN_TYPE_PASSIVE : WIFI_SCAN_TYPE_ACTIVE;
+  // Use shorter dwell times for roaming scans - we only need to detect strong
+  // nearby APs, not do a thorough survey. This also reduces off-channel time
+  // which can cause Beacon Timeout disconnects on some APs.
+  // Roaming times match the ESP32 IDF scan defaults.
+  static constexpr uint32_t SCAN_PASSIVE_DEFAULT_MS = 500;
+  static constexpr uint32_t SCAN_PASSIVE_ROAMING_MS = 300;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_DEFAULT_MS = 400;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_DEFAULT_MS = 500;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_ROAMING_MS = 100;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_ROAMING_MS = 300;
+  bool roaming = this->roaming_state_ == RoamingState::SCANNING;
   if (passive) {
-    config.scan_time.passive = 500;
+    config.scan_time.passive = roaming ? SCAN_PASSIVE_ROAMING_MS : SCAN_PASSIVE_DEFAULT_MS;
   } else {
-    config.scan_time.active.min = 400;
-    config.scan_time.active.max = 500;
+    config.scan_time.active.min = roaming ? SCAN_ACTIVE_MIN_ROAMING_MS : SCAN_ACTIVE_MIN_DEFAULT_MS;
+    config.scan_time.active.max = roaming ? SCAN_ACTIVE_MAX_ROAMING_MS : SCAN_ACTIVE_MAX_DEFAULT_MS;
   }
 #endif
   bool ret = wifi_station_scan(&config, &WiFiComponent::s_wifi_scan_done_callback);
@@ -725,7 +763,7 @@ void WiFiComponent::wifi_scan_done_callback_(void *arg, STATUS status) {
     }
   }
   ESP_LOGV(TAG, "Scan complete: %zu found, %zu stored%s", total, this->scan_result_.size(),
-           needs_full ? "" : " (filtered)");
+           needs_full ? LOG_STR_LITERAL("") : LOG_STR_LITERAL(" (filtered)"));
   this->scan_done_ = true;
 #ifdef USE_WIFI_SCAN_RESULTS_LISTENERS
   this->pending_.scan_complete = true;  // Defer listener callbacks to main loop
@@ -915,7 +953,10 @@ network::IPAddress WiFiComponent::wifi_gateway_ip_() {
   return network::IPAddress(&ip.gw);
 }
 network::IPAddress WiFiComponent::wifi_dns_ip_(int num) { return network::IPAddress(dns_getserver(num)); }
-void WiFiComponent::wifi_loop_() { this->process_pending_callbacks_(); }
+bool WiFiComponent::wifi_loop_() {
+  this->process_pending_callbacks_();
+  return true;
+}
 
 void WiFiComponent::process_pending_callbacks_() {
   // Process callbacks deferred from ESP8266 SDK system context (~2KB stack)
@@ -925,6 +966,8 @@ void WiFiComponent::process_pending_callbacks_() {
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
   if (this->pending_.disconnect) {
     this->pending_.disconnect = false;
+    // Refresh is_connected() cache here, not in the SDK callback (sys context).
+    this->update_connected_state_();
     this->notify_disconnect_state_listeners_();
   }
 #endif

--- a/components/wifi/wifi_component_esp_idf.cpp
+++ b/components/wifi/wifi_component_esp_idf.cpp
@@ -17,7 +17,7 @@
 #include <memory>
 #include <utility>
 #ifdef USE_WIFI_WPA2_EAP
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
 #include <esp_eap_client.h>
 #else
 #include <esp_wpa2.h>
@@ -47,7 +47,6 @@ namespace esphome::wifi {
 static const char *const TAG = "wifi_esp32";
 
 static EventGroupHandle_t s_wifi_event_group;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static QueueHandle_t s_event_queue;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static esp_netif_t *s_sta_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 #ifdef USE_WIFI_AP
 static esp_netif_t *s_ap_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -75,7 +74,11 @@ struct IDFWiFiEvent {
 #if USE_NETWORK_IPV6
     ip_event_got_ip6_t ip_got_ip6;
 #endif /* USE_NETWORK_IPV6 */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    ip_event_assigned_ip_to_client_t ip_assigned_ip_to_client;
+#else
     ip_event_ap_staipassigned_t ip_ap_staipassigned;
+#endif
   } data;
 };
 
@@ -116,18 +119,22 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     memcpy(&event.data.ap_staconnected, event_data, sizeof(wifi_event_ap_staconnected_t));
   } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_AP_STADISCONNECTED) {
     memcpy(&event.data.ap_stadisconnected, event_data, sizeof(wifi_event_ap_stadisconnected_t));
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  } else if (event_base == IP_EVENT && event_id == IP_EVENT_ASSIGNED_IP_TO_CLIENT) {
+    memcpy(&event.data.ip_assigned_ip_to_client, event_data, sizeof(ip_event_assigned_ip_to_client_t));
+#else
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_AP_STAIPASSIGNED) {
     memcpy(&event.data.ip_ap_staipassigned, event_data, sizeof(ip_event_ap_staipassigned_t));
+#endif
   } else {
     // did not match any event, don't send anything
     return;
   }
 
-  // copy to heap to keep queue object small
+  // copy to heap — WiFi events are rare so heap alloc is fine
   auto *to_send = new IDFWiFiEvent;  // NOLINT(cppcoreguidelines-owning-memory)
   memcpy(to_send, &event, sizeof(IDFWiFiEvent));
-  // don't block, we may miss events but the core can handle that
-  if (xQueueSend(s_event_queue, &to_send, 0L) != pdPASS) {
+  if (!global_wifi_component->event_queue_.push(to_send)) {
     delete to_send;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }
@@ -146,12 +153,6 @@ void WiFiComponent::wifi_pre_setup_() {
   s_wifi_event_group = xEventGroupCreate();
   if (s_wifi_event_group == nullptr) {
     ESP_LOGE(TAG, "xEventGroupCreate failed");
-    return;
-  }
-  // NOLINTNEXTLINE(bugprone-sizeof-expression)
-  s_event_queue = xQueueCreate(64, sizeof(IDFWiFiEvent *));
-  if (s_event_queue == nullptr) {
-    ESP_LOGE(TAG, "xQueueCreate failed");
     return;
   }
   err = esp_event_loop_create_default();
@@ -178,7 +179,10 @@ void WiFiComponent::wifi_pre_setup_() {
 #endif  // USE_WIFI_AP
 
   wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-  // cfg.nvs_enable = false;
+  if (global_preferences->nvs_handle == 0) {
+    ESP_LOGW(TAG, "starting wifi without nvs");
+    cfg.nvs_enable = false;
+  }
   err = esp_wifi_init(&cfg);
   if (err != ERR_OK) {
     ESP_LOGE(TAG, "esp_wifi_init failed: %s", esp_err_to_name(err));
@@ -403,11 +407,11 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
-  auto eap_opt = ap.get_eap();
+  const auto &eap_opt = ap.get_eap();
   if (eap_opt.has_value()) {
     // note: all certificates and keys have to be null terminated. Lengths are appended by +1 to include \0.
-    EAPAuth eap = *eap_opt;
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+    const EAPAuth &eap = *eap_opt;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
     err = esp_eap_client_set_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
 #else
     err = esp_wifi_sta_wpa2_ent_set_identity((uint8_t *) eap.identity.c_str(), eap.identity.length());
@@ -419,7 +423,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     int client_cert_len = strlen(eap.client_cert);
     int client_key_len = strlen(eap.client_key);
     if (ca_cert_len) {
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
       err = esp_eap_client_set_ca_cert((uint8_t *) eap.ca_cert, ca_cert_len + 1);
 #else
       err = esp_wifi_sta_wpa2_ent_set_ca_cert((uint8_t *) eap.ca_cert, ca_cert_len + 1);
@@ -432,7 +436,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     // validation is not required as the config tool has already validated it
     if (client_cert_len && client_key_len) {
       // if we have certs, this must be EAP-TLS
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
       err = esp_eap_client_set_certificate_and_key((uint8_t *) eap.client_cert, client_cert_len + 1,
                                                    (uint8_t *) eap.client_key, client_key_len + 1,
                                                    (uint8_t *) eap.password.c_str(), eap.password.length());
@@ -446,7 +450,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
       }
     } else {
       // in the absence of certs, assume this is username/password based
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
       err = esp_eap_client_set_username((uint8_t *) eap.username.c_str(), eap.username.length());
 #else
       err = esp_wifi_sta_wpa2_ent_set_username((uint8_t *) eap.username.c_str(), eap.username.length());
@@ -454,7 +458,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
       if (err != ESP_OK) {
         ESP_LOGV(TAG, "set_username failed %d", err);
       }
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
       err = esp_eap_client_set_password((uint8_t *) eap.password.c_str(), eap.password.length());
 #else
       err = esp_wifi_sta_wpa2_ent_set_password((uint8_t *) eap.password.c_str(), eap.password.length());
@@ -463,7 +467,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
         ESP_LOGV(TAG, "set_password failed %d", err);
       }
       // set TTLS Phase 2, defaults to MSCHAPV2
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
       err = esp_eap_client_set_ttls_phase2_method(eap.ttls_phase_2);
 #else
       err = esp_wifi_sta_wpa2_ent_set_ttls_phase2_method(eap.ttls_phase_2);
@@ -472,7 +476,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
         ESP_LOGV(TAG, "set_ttls_phase2_method failed %d", err);
       }
     }
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 1)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
     err = esp_wifi_sta_enterprise_enable();
 #else
     err = esp_wifi_sta_wpa2_ent_enable();
@@ -628,14 +632,26 @@ const char *get_disconnect_reason_str(uint8_t reason) {
       return "Auth Expired";
     case WIFI_REASON_AUTH_LEAVE:
       return "Auth Leave";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    case WIFI_REASON_DISASSOC_DUE_TO_INACTIVITY:
+      return "Disassociated Due to Inactivity";
+#else
     case WIFI_REASON_ASSOC_EXPIRE:
       return "Association Expired";
+#endif
     case WIFI_REASON_ASSOC_TOOMANY:
       return "Too Many Associations";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    case WIFI_REASON_CLASS2_FRAME_FROM_NONAUTH_STA:
+      return "Class 2 Frame from Non-Authenticated STA";
+    case WIFI_REASON_CLASS3_FRAME_FROM_NONASSOC_STA:
+      return "Class 3 Frame from Non-Associated STA";
+#else
     case WIFI_REASON_NOT_AUTHED:
       return "Not Authenticated";
     case WIFI_REASON_NOT_ASSOCED:
       return "Not Associated";
+#endif
     case WIFI_REASON_ASSOC_LEAVE:
       return "Association Leave";
     case WIFI_REASON_ASSOC_NOT_AUTHED:
@@ -688,7 +704,7 @@ const char *get_disconnect_reason_str(uint8_t reason) {
       return "Association comeback time too long";
     case WIFI_REASON_SA_QUERY_TIMEOUT:
       return "SA query timeout";
-#if (ESP_IDF_VERSION_MAJOR >= 5) && (ESP_IDF_VERSION_MINOR >= 2)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
     case WIFI_REASON_NO_AP_FOUND_W_COMPATIBLE_SECURITY:
       return "No AP found with compatible security";
     case WIFI_REASON_NO_AP_FOUND_IN_AUTHMODE_THRESHOLD:
@@ -702,19 +718,25 @@ const char *get_disconnect_reason_str(uint8_t reason) {
   }
 }
 
-void WiFiComponent::wifi_loop_() {
-  while (true) {
-    IDFWiFiEvent *data;
-    if (xQueueReceive(s_event_queue, &data, 0L) != pdTRUE) {
-      // no event ready
-      break;
-    }
+bool WiFiComponent::wifi_loop_() {
+  // Use pop() directly instead of empty() — pop() costs 1 memw (acquire on tail_),
+  // while empty() costs 2 memw (acquire on both head_ and tail_) on Xtensa.
+  IDFWiFiEvent *data = this->event_queue_.pop();
+  if (data == nullptr)
+    return false;
 
-    // process event
+  do {
     wifi_process_event_(data);
-
     delete data;  // NOLINT(cppcoreguidelines-owning-memory)
+  } while ((data = this->event_queue_.pop()) != nullptr);
+
+  // Drops only occur when the queue is full, and only this loop drains it,
+  // so if pop() returned nullptr above we can skip this check.
+  uint16_t dropped = this->event_queue_.get_and_reset_dropped_count();
+  if (dropped > 0) {
+    ESP_LOGW(TAG, "Dropped %u WiFi events due to buffer overflow", dropped);
   }
+  return true;
 }
 // Events are processed from queue in main loop context, but listener notifications
 // must be deferred until after the state machine transitions (in check_connecting_finished)
@@ -785,6 +807,8 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connected = false;
     s_sta_connecting = false;
     error_from_callback_ = true;
+    // Refresh is_connected() cache; error_from_callback_ makes it false.
+    this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     this->notify_disconnect_state_listeners_();
 #endif
@@ -917,8 +941,13 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     ESP_LOGV(TAG, "AP client disconnected MAC=%s", mac_buf);
 #endif
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_ASSIGNED_IP_TO_CLIENT) {
+    const auto &it = data->data.ip_assigned_ip_to_client;
+#else
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_AP_STAIPASSIGNED) {
     const auto &it = data->data.ip_ap_staipassigned;
+#endif
     ESP_LOGV(TAG, "AP client assigned IP " IPSTR, IP2STR(&it.ip));
   }
 }
@@ -961,6 +990,13 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
     config.scan_time.active.min = 100;
     config.scan_time.active.max = 300;
   }
+  // When scanning while connected (roaming), return to home channel between
+  // each scanned channel to maintain the connection (helps with BLE/WiFi coexistence)
+#ifdef CONFIG_SOC_WIFI_SUPPORTED
+  if (this->roaming_state_ == RoamingState::SCANNING) {
+    config.coex_background_scan = true;
+  }
+#endif
 
   esp_err_t err = esp_wifi_scan_start(&config, false);
   if (err != ESP_OK) {

--- a/components/wifi/wifi_component_libretiny.cpp
+++ b/components/wifi/wifi_component_libretiny.cpp
@@ -10,12 +10,14 @@
 #include "lwip/err.h"
 #include "lwip/dns.h"
 
-#include <FreeRTOS.h>
-#include <queue.h>
-
 #ifdef USE_BK72XX
 extern "C" {
+// BDK 3.0.78 (required for BK7238) redeclares wifi_event_sta_disconnected_t,
+// which LibreTiny's Arduino WiFi API already defines. ESPHome doesn't use the
+// BDK version, so rename it across this include to avoid the collision.
+#define wifi_event_sta_disconnected_t bdk_wifi_event_sta_disconnected_t
 #include <wlan_ui_pub.h>
+#undef wifi_event_sta_disconnected_t
 }
 #endif
 
@@ -43,16 +45,13 @@ static const char *const TAG = "wifi_lt";
 // (like connection status flags) from the callback causes race conditions:
 // - The main loop may never see state changes (values cached in registers)
 // - State changes may be visible in inconsistent order
-// - LibreTiny targets (BK7231, RTL8720) lack atomic instructions (no LDREX/STREX)
 //
 // Solution: Queue events in the callback and process them in the main loop.
 // This is the same approach used by ESP32 IDF's wifi_process_event_().
 // All state modifications happen in the main loop context, eliminating races.
-
-static constexpr size_t EVENT_QUEUE_SIZE = 16;  // Max pending WiFi events before overflow
-static QueueHandle_t s_event_queue = nullptr;   // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static volatile uint32_t s_event_queue_overflow_count =
-    0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+//
+// On platforms with hardware atomics (RTL87xx, LN882x): LockFreeQueue (SPSC ring buffer)
+// On platforms without (BK72xx): FreeRTOSQueue (xQueue wrapper with critical sections)
 
 // Event structure for queued WiFi events - contains a copy of event data
 // to avoid lifetime issues with the original event data from the callback
@@ -96,8 +95,6 @@ enum class LTWiFiSTAState : uint8_t {
   ERROR_NOT_FOUND,  // AP not found (probe failed)
   ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
 };
-
-static LTWiFiSTAState s_sta_state = LTWiFiSTAState::IDLE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // Count of ignored disconnect events during connection - too many indicates real failure
 static uint8_t s_ignored_disconnect_count = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -223,7 +220,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   this->wifi_apply_hostname_();
 
   // Reset state machine and disconnect counter before connecting
-  s_sta_state = LTWiFiSTAState::CONNECTING;
+  this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::CONNECTING);
   s_ignored_disconnect_count = 0;
 
   WiFiStatus status = WiFi.begin(ap.ssid_.c_str(), ap.password_.empty() ? NULL : ap.password_.c_str(),
@@ -354,10 +351,6 @@ using esphome_wifi_event_info_t = arduino_event_info_t;
 // Event callback - runs in WiFi driver thread context
 // Only queues events for processing in main loop, no logging or state changes here
 void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_wifi_event_info_t info) {
-  if (s_event_queue == nullptr) {
-    return;
-  }
-
   // Allocate on heap and fill directly to avoid extra memcpy
   auto *to_send = new LTWiFiEvent{};  // NOLINT(cppcoreguidelines-owning-memory)
   to_send->event_id = event;
@@ -430,9 +423,8 @@ void WiFiComponent::wifi_event_callback_(esphome_wifi_event_id_t event, esphome_
   }
 
   // Queue event (don't block if queue is full)
-  if (xQueueSend(s_event_queue, &to_send, 0) != pdPASS) {
+  if (!this->event_queue_.push(to_send)) {
     delete to_send;  // NOLINT(cppcoreguidelines-owning-memory)
-    s_event_queue_overflow_count++;
   }
 }
 
@@ -459,7 +451,7 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
     }
     case ESPHOME_EVENT_ID_WIFI_STA_STOP: {
       ESP_LOGV(TAG, "STA stop");
-      s_sta_state = LTWiFiSTAState::IDLE;
+      this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::IDLE);
       break;
     }
     case ESPHOME_EVENT_ID_WIFI_STA_CONNECTED: {
@@ -479,7 +471,7 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       // For static IP configurations, GOT_IP event may not fire, so set connected state here
 #ifdef USE_WIFI_MANUAL_IP
       if (const WiFiAP *config = this->get_selected_sta_(); config && config->get_manual_ip().has_value()) {
-        s_sta_state = LTWiFiSTAState::CONNECTED;
+        this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::CONNECTED);
 #ifdef USE_WIFI_IP_STATE_LISTENERS
         this->notify_ip_state_listeners_();
 #endif
@@ -501,12 +493,13 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       // Only ignore benign reasons - real failures like NO_AP_FOUND should still be processed.
       // However, if we get too many of these events (IGNORED_DISCONNECT_THRESHOLD), treat it
       // as a real connection failure to avoid waiting the full timeout for a failing connection.
-      if (it.ssid_len == 0 && s_sta_state == LTWiFiSTAState::CONNECTING && it.reason != WIFI_REASON_NO_AP_FOUND) {
+      if (it.ssid_len == 0 && this->sta_state_ == static_cast<uint8_t>(LTWiFiSTAState::CONNECTING) &&
+          it.reason != WIFI_REASON_NO_AP_FOUND) {
         s_ignored_disconnect_count++;
         if (s_ignored_disconnect_count >= IGNORED_DISCONNECT_THRESHOLD) {
           ESP_LOGW(TAG, "Too many disconnect events (%u) while connecting, treating as failure (reason=%s)",
                    s_ignored_disconnect_count, get_disconnect_reason_str(it.reason));
-          s_sta_state = LTWiFiSTAState::ERROR_FAILED;
+          this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::ERROR_FAILED);
           WiFi.disconnect();
           this->error_from_callback_ = true;
           // Don't break - fall through to notify listeners
@@ -520,13 +513,13 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       if (it.reason == WIFI_REASON_NO_AP_FOUND) {
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
                  (const char *) it.ssid);
-        s_sta_state = LTWiFiSTAState::ERROR_NOT_FOUND;
+        this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::ERROR_NOT_FOUND);
       } else {
         char bssid_s[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
         format_mac_addr_upper(it.bssid, bssid_s);
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
                  (const char *) it.ssid, bssid_s, get_disconnect_reason_str(it.reason));
-        s_sta_state = LTWiFiSTAState::ERROR_FAILED;
+        this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::ERROR_FAILED);
       }
 
       uint8_t reason = it.reason;
@@ -537,6 +530,8 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
         this->error_from_callback_ = true;
       }
 
+      // Refresh is_connected() cache; sta_state_/error_from_callback_ make it false.
+      this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       this->notify_disconnect_state_listeners_();
 #endif
@@ -551,7 +546,7 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
         ESP_LOGW(TAG, "Potential Authmode downgrade detected, disconnecting");
         WiFi.disconnect();
         this->error_from_callback_ = true;
-        s_sta_state = LTWiFiSTAState::ERROR_FAILED;
+        this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::ERROR_FAILED);
       }
       break;
     }
@@ -559,7 +554,7 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
       char ip_buf[network::IP_ADDRESS_BUFFER_SIZE], gw_buf[network::IP_ADDRESS_BUFFER_SIZE];
       ESP_LOGV(TAG, "static_ip=%s gateway=%s", network::IPAddress(WiFi.localIP()).str_to(ip_buf),
                network::IPAddress(WiFi.gatewayIP()).str_to(gw_buf));
-      s_sta_state = LTWiFiSTAState::CONNECTED;
+      this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::CONNECTED);
 #ifdef USE_WIFI_IP_STATE_LISTENERS
       this->notify_ip_state_listeners_();
 #endif
@@ -621,23 +616,15 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
   }
 }
 void WiFiComponent::wifi_pre_setup_() {
-  // Create event queue for thread-safe event handling
-  // Events are pushed from WiFi callback thread and processed in main loop
-  s_event_queue = xQueueCreate(EVENT_QUEUE_SIZE, sizeof(LTWiFiEvent *));
-  if (s_event_queue == nullptr) {
-    ESP_LOGE(TAG, "Failed to create event queue");
-    return;
-  }
-
-  auto f = std::bind(&WiFiComponent::wifi_event_callback_, this, std::placeholders::_1, std::placeholders::_2);
-  WiFi.onEvent(f);
+  WiFi.onEvent(
+      [this](arduino_event_id_t event, arduino_event_info_t info) { this->wifi_event_callback_(event, info); });
   // Make sure WiFi is in clean state before anything starts
   this->wifi_mode_(false, false);
 }
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // Use state machine instead of querying WiFi.status() directly
   // State is updated in main loop from queued events, ensuring thread safety
-  switch (s_sta_state) {
+  switch (static_cast<LTWiFiSTAState>(this->sta_state_)) {
     case LTWiFiSTAState::CONNECTED:
       return WiFiSTAConnectStatus::CONNECTED;
     case LTWiFiSTAState::ERROR_NOT_FOUND:
@@ -758,7 +745,7 @@ network::IPAddress WiFiComponent::wifi_soft_ap_ip() { return {WiFi.softAPIP()}; 
 bool WiFiComponent::wifi_disconnect_() {
   // Reset state first so disconnect events aren't ignored
   // and wifi_sta_connect_status_() returns IDLE instead of CONNECTING
-  s_sta_state = LTWiFiSTAState::IDLE;
+  this->sta_state_ = static_cast<uint8_t>(LTWiFiSTAState::IDLE);
   return WiFi.disconnect();
 }
 
@@ -797,28 +784,26 @@ int32_t WiFiComponent::get_wifi_channel() { return WiFi.channel(); }
 network::IPAddress WiFiComponent::wifi_subnet_mask_() { return {WiFi.subnetMask()}; }
 network::IPAddress WiFiComponent::wifi_gateway_ip_() { return {WiFi.gatewayIP()}; }
 network::IPAddress WiFiComponent::wifi_dns_ip_(int num) { return {WiFi.dnsIP(num)}; }
-void WiFiComponent::wifi_loop_() {
-  // Process all pending events from the queue
-  if (s_event_queue == nullptr) {
-    return;
-  }
+bool WiFiComponent::wifi_loop_() {
+  // Use pop() directly instead of empty() — avoids redundant synchronization.
+  // LockFreeQueue: pop() costs 1 memw vs empty()'s 2 memw on Xtensa.
+  // FreeRTOSQueue: pop() is 1 critical section vs empty() + pop() = 2.
+  LTWiFiEvent *event = this->event_queue_.pop();
+  if (event == nullptr)
+    return false;
 
-  // Check for dropped events due to queue overflow
-  if (s_event_queue_overflow_count > 0) {
-    ESP_LOGW(TAG, "Event queue overflow, %" PRIu32 " events dropped", s_event_queue_overflow_count);
-    s_event_queue_overflow_count = 0;
-  }
-
-  while (true) {
-    LTWiFiEvent *event;
-    if (xQueueReceive(s_event_queue, &event, 0) != pdTRUE) {
-      // No more events
-      break;
-    }
-
+  do {
     wifi_process_event_(event);
     delete event;  // NOLINT(cppcoreguidelines-owning-memory)
+  } while ((event = this->event_queue_.pop()) != nullptr);
+
+  // Drops only occur when the queue is full, and only this loop drains it,
+  // so if pop() returned nullptr above we can skip this check.
+  uint16_t dropped = this->event_queue_.get_and_reset_dropped_count();
+  if (dropped > 0) {
+    ESP_LOGW(TAG, "Dropped %" PRIu16 " WiFi events due to buffer overflow", dropped);
   }
+  return true;
 }
 
 }  // namespace esphome::wifi

--- a/components/wifi/wifi_component_pico_w.cpp
+++ b/components/wifi/wifi_component_pico_w.cpp
@@ -303,7 +303,7 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
 // Connect state listener notifications are deferred until after the state machine
 // transitions (in check_connecting_finished) so that conditions like wifi.connected
 // return correct values in automations.
-void WiFiComponent::wifi_loop_() {
+bool WiFiComponent::wifi_loop_() {
   // Handle scan completion
   if (this->state_ == WIFI_COMPONENT_STATE_STA_SCANNING && !cyw43_wifi_scan_active(&cyw43_state)) {
     this->scan_done_ = true;
@@ -342,6 +342,8 @@ void WiFiComponent::wifi_loop_() {
     s_sta_was_connected = false;
     s_sta_had_ip = false;
     ESP_LOGV(TAG, "Disconnected");
+    // Refresh is_connected() cache; driver link status reports disconnected.
+    this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     this->notify_disconnect_state_listeners_();
 #endif
@@ -365,6 +367,7 @@ void WiFiComponent::wifi_loop_() {
 #endif
     }
   }
+  return true;
 }
 
 void WiFiComponent::wifi_pre_setup_() {}

--- a/components/wifi/wpa2_eap.py
+++ b/components/wifi/wpa2_eap.py
@@ -67,13 +67,15 @@ def _validate_load_certificate(value):
         contents = read_relative_config_path(value)
         return wrapped_load_pem_x509_certificate(contents)
     except ValueError as err:
-        raise cv.Invalid(f"Invalid certificate: {err}")
+        raise cv.Invalid(f"Invalid certificate: {err}") from err
 
 
 def validate_certificate(value):
+    # _validate_load_certificate already calls cv.file_() internally,
+    # but returns the parsed certificate object.  We re-call cv.file_()
+    # to get the resolved path string that the bundle walker can discover.
     _validate_load_certificate(value)
-    # Validation result should be the path, not the loaded certificate
-    return value
+    return str(cv.file_(value))
 
 
 def _validate_load_private_key(key, cert_pw):
@@ -84,9 +86,9 @@ def _validate_load_private_key(key, cert_pw):
     except ValueError as e:
         raise cv.Invalid(
             f"There was an error with the EAP 'password:' provided for 'key' {e}"
-        )
+        ) from e
     except TypeError as e:
-        raise cv.Invalid(f"There was an error with the EAP 'key:' provided: {e}")
+        raise cv.Invalid(f"There was an error with the EAP 'key:' provided: {e}") from e
 
 
 def _check_private_key_cert_match(key, cert):


### PR DESCRIPTION
## Summary

This PR upgrades ESPHome from 2026.3.0 to 2026.5.0 and adds support for configuring WiFi PHY mode on ESP8266 devices. The upgrade includes numerous bug fixes, improvements to WiFi roaming logic, RP2040 WiFi support, and better event handling across platforms.

## Key Changes

### ESPHome Upgrade (2026.3.0 → 2026.5.0)
- Updated WiFi component to latest upstream version with improved roaming state machine
- Added RP2040 WiFi board detection and validation
- Improved event queue handling for ESP32 and LibreTiny platforms
- Fixed ESP32 IDF version checks to use `ESP_IDF_VERSION_VAL()` macro
- Enhanced WiFi connection state tracking with better caching to reduce polling overhead
- Added support for checking placeholder WiFi credentials before compilation

### WiFi PHY Mode Support (ESP8266)
- Added `CONF_PHY_MODE` configuration option for ESP8266 devices
- Implemented `WiFi8266PhyMode` enum with AUTO, 11B, 11G, and 11N modes
- Added `wifi_apply_phy_mode_()` method to apply PHY mode settings during WiFi initialization
- PHY mode configuration is only available on ESP8266 platform (validated via `cv.only_on_esp8266`)

### WiFi Capability Detection
- Added `variant_has_wifi()` function to check if ESP32 variants have native WiFi (excludes ESP32-H2, ESP32-P4)
- Added `has_native_wifi()` dispatcher function for external tools (device-builder) to determine WiFi support across platforms
- Added RP2040 WiFi board validation with helpful error messages for boards without WiFi support

### Event Queue Improvements
- Replaced FreeRTOS queue with platform-specific implementations:
  - ESP32: Uses `LockFreeQueue` (SPSC ring buffer)
  - LibreTiny with atomics: Uses `LockFreeQueue`
  - LibreTiny without atomics: Uses `FreeRTOSQueue` with critical sections
- Improved event handling to return boolean indicating whether events were processed
- Optimized `loop()` to skip expensive connection status polling when no events arrived

### WiFi Roaming State Machine
- Enhanced roaming disconnect handling with grace period (30 seconds) after scan completion
- Improved state transitions to distinguish between roaming success on target BSSID vs. other APs
- Better counter preservation logic for roaming failures vs. non-roaming disconnects
- Updated state machine documentation with clearer transition diagrams

### Code Quality Improvements
- Converted global static WiFi state variables to instance members (ESP8266, LibreTiny)
- Inlined simple getter methods (`has_sta()`, `has_ap()`, `is_ap_active()`, `get_use_address()`)
- Fixed EAP authentication to use const references instead of copies
- Improved power save mode comments for ESP8266 (clarified LIGHT_SLEEP_T vs MODEM_SLEEP_T behavior)
- Added helper function `phy_mode_to_log_string()` for PHY mode logging on ESP8266

### Platform-Specific Fixes
- **ESP32**: Fixed NVS initialization check and improved event queue handling
- **ESP8266**: Refactored WiFi STA state tracking with enum instead of multiple booleans
- **LibreTiny**: Added BDK 3.0.78 compatibility for BK7238 (renamed conflicting struct)
- **RP2040**: Added WiFi board detection and validation with helpful error messages

### Documentation
- Added `README.md` documenting the forked WiFi component and AP+STA simultaneous operation patch
- Included instructions for updating to newer ESPHome releases

## Notable Implementation Details

- The WiFi component is now marked as `final` to prevent subclassing
- Connection state caching (`connected_` member) reduces expensive `wifi_sta_connect_status_()` calls
- Event processing now returns a boolean to optimize the main loop
- Platform-specific event queues use

https://claude.ai/code/session_014BZn3tcCvx4ZGGkzmsxJeg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PHY mode configuration option for ESP8266 devices.
  * Added compile-time validation for placeholder WiFi credentials to catch missing configurations.

* **Bug Fixes**
  * Improved WiFi connection state tracking and roaming behavior across multiple platforms.
  * Enhanced error messages for WPA2 EAP certificate and key validation.

* **Chores**
  * Updated CI workflow to use ESPHome 2026.5.0.
  * Added documentation for WiFi component fork maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tomquist/marsrelay/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->