### PR TITLE
Add timezone support to sync battery clock with local time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ substitutions:
   mqtt_username: ""
   mqtt_password: ""
   mqtt_topic_prefix: "marsrelay"
+  # Timezone used to sync the battery clock (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+  timezone: "Europe/Berlin"
   # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
@@ -105,6 +107,13 @@ external_components:
       ref: main
 
 logger:
+
+# Keeps the ESP32 system clock in sync so the marstack component serves the
+# correct date/time to the battery (GET /app/neng/getDateInfoeu.php).
+time:
+  - platform: sntp
+    id: sntp_time
+    timezone: ${timezone}
 
 wifi:
   ssid: ${wifi_ssid}
@@ -189,6 +198,7 @@ Edit the `substitutions` section at the top of the configuration file:
 - **`ap_ssid`** and **`ap_password`**: The WiFi network name and password that your Marstek device will connect to (default is "marsrelay" / "marsrelay")
 - **`mqtt_broker`**: The IP address of your MQTT broker (e.g., `192.168.1.100`)
 - **`mqtt_username`** and **`mqtt_password`**: Your MQTT broker credentials (leave empty if not required)
+- **`timezone`**: Your local timezone (e.g. `Europe/Berlin`). Marsrelay uses this to keep the battery's clock in sync; if it's wrong the battery time will be off. See the [list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 - **`psram.enabled`** and **`psram.mode`**: Set according to your ESP32-S3 board specifications
 
 ### Step 3: Build and Flash

--- a/components/marstack/marstack.cpp
+++ b/components/marstack/marstack.cpp
@@ -53,7 +53,11 @@ void log_query_params(AsyncWebServerRequest *request, const char *path) {
 std::string formatted_date_string() {
   time_t now = time(nullptr);
   struct tm timeinfo;
-  gmtime_r(&now, &timeinfo);
+  // Use local time so the date handed to the battery honors the configured
+  // timezone. This relies on the system clock being set by a `time:` platform
+  // (e.g. sntp); without one the clock stays at ~1970 and the battery's time
+  // ends up out of sync.
+  localtime_r(&now, &timeinfo);
   char buffer[64];
   snprintf(buffer, sizeof(buffer), "_%04d_%02d_%02d_%02d_%02d_%02d_04_0_0_0", timeinfo.tm_year + 1900,
            timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -9,6 +9,8 @@ substitutions:
   mqtt_username: "mqtt_user"
   mqtt_password: "mqtt_password"
   mqtt_topic_prefix: "marsrelay"
+  # Timezone used to sync the battery clock (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+  timezone: "Europe/Berlin"
   # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
@@ -49,6 +51,13 @@ external_components:
       path: ./components
 
 logger:
+
+# Keeps the ESP32 system clock in sync so the marstack component serves the
+# correct date/time to the battery (GET /app/neng/getDateInfoeu.php).
+time:
+  - platform: sntp
+    id: sntp_time
+    timezone: ${timezone}
 
 wifi:
   ssid: ${wifi_ssid}


### PR DESCRIPTION
## Summary
This PR adds timezone configuration support to ensure the Marstek battery's clock is synchronized with the local timezone. Previously, the system was using UTC time, which could cause the battery's clock to be out of sync with the user's local time.

## Key Changes
- **Configuration**: Added a new `timezone` substitution variable (defaults to "Europe/Berlin") in both README and example configuration files
- **Time Synchronization**: Integrated SNTP (Simple Network Time Protocol) time platform to keep the ESP32 system clock synchronized
- **Local Time Usage**: Changed `marstack.cpp` to use `localtime_r()` instead of `gmtime_r()` when formatting the date string sent to the battery, ensuring it respects the configured timezone
- **Documentation**: Updated README with instructions on how to configure the timezone using the [IANA timezone database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)

## Implementation Details
- The SNTP time platform is configured in the ESPHome YAML to automatically sync the system clock
- The `formatted_date_string()` function now uses local time instead of GMT, with comments explaining the dependency on the `time:` platform being configured
- Without proper timezone configuration, the battery's clock will remain out of sync, so this is now a required configuration step

https://claude.ai/code/session_01C3wWXQ9nxGjUNEsrz5LxYM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device now synchronizes its clock via NTP and respects configured timezone settings for accurate local timestamps in all date/time outputs.

* **Documentation**
  * Updated setup instructions with timezone configuration guidance and time synchronization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->