### PR TITLE
Derive CI esphome_version from UPSTREAM_VERSION file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,23 @@ on:
   pull_request:
 
 jobs:
+  # Read the ESPHome pin from components/wifi/UPSTREAM_VERSION rather than
+  # hardcoding it here. Keeping the version out of the workflow file lets the
+  # automated wifi-update-check bump land in an ordinary commit that the default
+  # GITHUB_TOKEN can push (App tokens can't touch .github/workflows/ without the
+  # `workflows` permission, which isn't grantable to GITHUB_TOKEN).
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      esphome_version: ${{ steps.pin.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: pin
+        run: echo "version=$(cat components/wifi/UPSTREAM_VERSION)" >> "$GITHUB_OUTPUT"
+
   ci:
+    needs: version
     uses: ./.github/workflows/ci-dispatch.yml
     with:
-      esphome_version: "2026.6.3"
+      esphome_version: ${{ needs.version.outputs.esphome_version }}
       run_tests: true

--- a/components/wifi/README.md
+++ b/components/wifi/README.md
@@ -63,9 +63,10 @@ The script:
    vendor import), git does a true three-way merge: where upstream rewrote a
    patched region you get **standard conflict markers** to resolve, not a silent
    mis-apply.
-3. Regenerates the patch against the new base, bumps `UPSTREAM_VERSION`, the CI
-   `esphome_version` pin, and the **Current base** above, then runs
-   `scripts/check-wifi-fork.sh` to prove the result is exactly upstream + patch.
+3. Regenerates the patch against the new base, bumps `UPSTREAM_VERSION` and the
+   **Current base** above, then runs `scripts/check-wifi-fork.sh` to prove the
+   result is exactly upstream + patch. CI reads its `esphome_version` from
+   `UPSTREAM_VERSION`, so no workflow file needs editing on a bump.
 
 If the merge is clean the script leaves the re-apply staged for you to review and
 commit; if it conflicts it prints the steps to finish manually. Either way, then

--- a/scripts/update-wifi.sh
+++ b/scripts/update-wifi.sh
@@ -67,8 +67,8 @@ else
 !! conflict markers. Resolve them, then finish manually:
 
      git diff HEAD -- components/wifi/wifi_component.cpp > $PATCH
-     # bump esphome_version in .github/workflows/ci.yml and the "Current base"
-     # in components/wifi/README.md to ${VERSION}
+     # bump the "Current base" / Upstream version in components/wifi/README.md
+     # to ${VERSION} (UPSTREAM_VERSION and the CI pin are already handled)
      scripts/check-wifi-fork.sh
      git add -A && git commit -m "Re-apply marsrelay patch on esphome wifi ${VERSION}"
 EOF
@@ -82,8 +82,10 @@ echo "==> Regenerating patch against the new base"
 git -C "$ROOT" diff HEAD -- components/wifi/wifi_component.cpp > "$PATCH"
 
 echo "==> Bumping version markers"
-sed -i -E "s/esphome_version: \"[0-9][0-9.]*\"/esphome_version: \"${VERSION}\"/" \
-  "$ROOT/.github/workflows/ci.yml"
+# The CI esphome pin is derived from components/wifi/UPSTREAM_VERSION (already
+# written above), so the workflow files are intentionally left untouched here --
+# that keeps the automated wifi-update-check commit pushable with the default
+# GITHUB_TOKEN, which can't modify .github/workflows/ without `workflows` perms.
 sed -i -E "s#tree/[0-9][0-9.]*/esphome/components/wifi#tree/${VERSION}/esphome/components/wifi#" \
   "$WIFI_DIR/README.md"
 sed -i -E "s/\*\*Upstream version:\*\* \`[0-9][0-9.]*\`/**Upstream version:** \`${VERSION}\`/" \
@@ -91,8 +93,6 @@ sed -i -E "s/\*\*Upstream version:\*\* \`[0-9][0-9.]*\`/**Upstream version:** \`
 
 # Fail loudly if any substitution silently no-op'd (e.g. a marker format drifted),
 # which would otherwise leave stale version pins behind.
-grep -qF "esphome_version: \"${VERSION}\"" "$ROOT/.github/workflows/ci.yml" \
-  || { echo "ERROR: esphome_version not bumped in ci.yml" >&2; exit 1; }
 grep -qF "tree/${VERSION}/esphome/components/wifi" "$WIFI_DIR/README.md" \
   || { echo "ERROR: upstream tree URL not bumped in README.md" >&2; exit 1; }
 grep -qF "**Upstream version:** \`${VERSION}\`" "$WIFI_DIR/README.md" \


### PR DESCRIPTION
## Summary

Moves the ESPHome version pin from a hardcoded value in the CI workflow to a dynamic read from `components/wifi/UPSTREAM_VERSION`. This allows the automated wifi-update-check script to bump the version in a single file, enabling the default `GITHUB_TOKEN` to push the commit without requiring elevated `workflows` permissions.

## Key Changes

- **`.github/workflows/ci.yml`**: Added a new `version` job that reads `components/wifi/UPSTREAM_VERSION` and outputs it as `esphome_version`. The `ci` job now depends on this and uses the dynamic version instead of the hardcoded `"2026.6.3"`.

- **`scripts/update-wifi.sh`**: Removed the sed command that bumped `esphome_version` in `ci.yml`. Updated comments to clarify that the CI pin is now derived from `UPSTREAM_VERSION` and that workflow files are intentionally left untouched to keep the commit pushable with default token permissions.

- **`components/wifi/README.md`**: Updated documentation to reflect that CI reads its version from `UPSTREAM_VERSION`, eliminating the need to manually edit workflow files during version bumps.

## Implementation Details

The `version` job uses a simple shell command to read the version file and export it via GitHub Actions outputs. This approach:
- Keeps version information in a single source of truth (`UPSTREAM_VERSION`)
- Avoids the permission issue where `GITHUB_TOKEN` cannot modify `.github/workflows/` without the `workflows` scope
- Simplifies the `update-wifi.sh` script by removing one less file to update

https://claude.ai/code/session_01F8TzATN3aTUK2UvBpE4Njc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now automatically uses the ESPHome version recorded in the WiFi component.
  * WiFi update instructions and automation were streamlined to keep version information synchronized in the appropriate locations.
  * Improved update-script guidance and validation when applying upstream WiFi changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->