### PR TITLE
Authenticate wifi-update-check via a GitHub App token

### DIFF
--- a/.github/workflows/wifi-update-check.yml
+++ b/.github/workflows/wifi-update-check.yml
@@ -14,9 +14,14 @@ name: wifi-update-check
 # failure. The detection logic lives in scripts/check-wifi-upstream.sh; the
 # actual re-vendor + patch re-apply reuses scripts/update-wifi.sh.
 #
-# Set the optional secret WIFI_UPDATE_TOKEN to a PAT to have the generated PR's
-# own CI (CI / wifi-fork-check) run; with the default GITHUB_TOKEN, pushes from
-# this workflow don't trigger other workflows.
+# Authentication: the default GITHUB_TOKEN cannot open the PR here -- GitHub
+# blocks Actions from creating pull requests. Configure a GitHub App instead by
+# setting the WIFI_UPDATE_APP_ID repo *variable* and the WIFI_UPDATE_APP_PRIVATE_KEY
+# repo *secret* (App needs Contents: RW + Pull requests: RW; see
+# components/wifi/README.md for the one-time setup). The minted App token opens the
+# PR and, unlike GITHUB_TOKEN, its push triggers the generated PR's own CI
+# (CI / wifi-fork-check). Without the App configured the job falls back to
+# GITHUB_TOKEN: change detection still works, but opening a PR will fail.
 
 on:
   schedule:
@@ -31,23 +36,35 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token from the GitHub App when it's configured. The App
+      # ID isn't sensitive (repo variable); only the private key is a secret. When
+      # the App isn't set up the step is skipped and everything falls back to
+      # github.token via the `|| github.token` below.
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ vars.WIFI_UPDATE_APP_ID != '' }}
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.WIFI_UPDATE_APP_ID }}
+          private-key: ${{ secrets.WIFI_UPDATE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: true
-          token: ${{ secrets.WIFI_UPDATE_TOKEN || github.token }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Detect upstream wifi change
         id: detect
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: ./scripts/check-wifi-upstream.sh
 
       - name: Look for an existing auto-update PR
         if: steps.detect.outputs.changed == 'true'
         id: existing
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
         run: |
           count=$(gh pr list --state open --json headRefName \
             --jq '[.[] | select(.headRefName | startswith("automated/update-wifi-"))] | length')
@@ -59,7 +76,7 @@ jobs:
         id: update
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           WIFI_VERSION: ${{ steps.detect.outputs.latest }}
         run: |
           git config user.name "github-actions[bot]"
@@ -71,7 +88,7 @@ jobs:
       - name: Open pull request
         if: steps.detect.outputs.changed == 'true' && steps.existing.outputs.count == '0' && steps.update.outcome == 'success'
         env:
-          GH_TOKEN: ${{ secrets.WIFI_UPDATE_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
           WIFI_VERSION: ${{ steps.detect.outputs.latest }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |

--- a/components/wifi/README.md
+++ b/components/wifi/README.md
@@ -103,9 +103,29 @@ component actually changed:
   manual `scripts/update-wifi.sh <version>` + conflict resolution is needed.
 
 So the only red state is "upstream changed the component in a way we can't carry
-over automatically". Set the optional `WIFI_UPDATE_TOKEN` secret (a PAT) if you
-want the generated PR's own CI to run — pushes made with the default
-`GITHUB_TOKEN` don't trigger other workflows.
+over automatically".
+
+### Authenticating the auto-update PR (GitHub App)
+
+Opening the PR needs a token the default `GITHUB_TOKEN` can't provide: GitHub
+blocks Actions from creating pull requests, and `GITHUB_TOKEN` pushes don't
+trigger the new PR's own CI. A GitHub App token fixes both. One-time setup:
+
+1. Create a GitHub App (Settings → Developer settings → GitHub Apps → *New GitHub
+   App*). Give it any name; set Homepage URL to the repo; **uncheck** *Webhook →
+   Active*.
+2. Under *Repository permissions* grant **Contents: Read and write** and **Pull
+   requests: Read and write**, then create the App.
+3. On the App's page, note its **App ID**, and click *Generate a private key* to
+   download the `.pem`.
+4. *Install App* → install it on this repository (only-select-repositories).
+5. In the repo, add **Settings → Secrets and variables → Actions**:
+   - a **variable** named `WIFI_UPDATE_APP_ID` = the App ID
+   - a **secret** named `WIFI_UPDATE_APP_PRIVATE_KEY` = the full `.pem` contents
+
+With those set, `wifi-update-check` mints an App token, opens the
+`automated/update-wifi-<version>` PR, and the App's push triggers that PR's CI.
+Leave them unset and the job still detects upstream changes but can't open a PR.
 
 ## Why a full fork (instead of a small override)
 


### PR DESCRIPTION
## Problem

After the earlier fix (#34) let the auto-update job push its branch, the `wifi-update-check` workflow still failed at the next step:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

The default `GITHUB_TOKEN` is blocked from opening pull requests, and its pushes also don't trigger the generated PR's own CI — so even if PR creation were allowed, the update PR would sit with no checks.

## Change

Authenticate the workflow with a **GitHub App** token instead:

- New *Generate GitHub App token* step (`actions/create-github-app-token@v2`), gated on the `WIFI_UPDATE_APP_ID` repo **variable**. Every subsequent step uses `${{ steps.app-token.outputs.token || github.token }}`, so when the App isn't configured the job cleanly falls back to `GITHUB_TOKEN` (change detection still works; only PR creation needs the App).
- An App token can open PRs (the block only applies to `GITHUB_TOKEN`) and, unlike `GITHUB_TOKEN`, its push triggers the new PR's own CI.
- Replaces the previous optional `WIFI_UPDATE_TOKEN` PAT path.

Because the automation no longer edits any workflow file (thanks to #34), the App only needs **Contents: RW** + **Pull requests: RW** — no `workflows` scope.

## Required one-time setup (repo admin)

The workflow stays a fallback no-op until a GitHub App is configured:

1. Create a GitHub App with **Contents: RW** + **Pull requests: RW**, webhook disabled.
2. Generate its private key and install it on this repository.
3. Add repo **variable** `WIFI_UPDATE_APP_ID` = the App ID, and repo **secret** `WIFI_UPDATE_APP_PRIVATE_KEY` = the `.pem` contents.

Full step-by-step is documented in `components/wifi/README.md`.

## Notes

- No firmware/component code changes; only the workflow and docs.
- YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8TzATN3aTUK2UvBpE4Njc)_