### PR TITLE
Support encrypted device IDs and hame_energy topic prefix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Edit the `substitutions` section at the top of the configuration file:
 
 Depending on the battery's firmware version, the `deviceId` in the topic is either the battery's Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`) or a much longer encrypted ID. Both are normal — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for what this means for your hm2mqtt configuration.
 
-If no `/device/` topic ever shows up, see [Troubleshooting](#troubleshooting).
+If nothing has appeared after 20 minutes, you don't have to keep waiting: you can look the device ID up via Hame Relay instead — temporarily install it with your Marstek account credentials and read the ID from its startup logs (see [Finding the encrypted ID](#finding-the-encrypted-id) for the details). Also work through [Troubleshooting](#troubleshooting), because a missing `/device/` topic usually means the battery isn't sending data yet — knowing the ID alone won't fix that.
 
 ### Step 6: Configure hm2mqtt
 
@@ -283,38 +283,17 @@ Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://githu
 
 ## Device IDs: MAC Address vs. Encrypted ID
 
-Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g.
-`009b08a571ee`). This is what [hm2mqtt](https://github.com/tomquist/hm2mqtt)
-normally uses as the `deviceId`, and it's shown in the Marstek app and
-Bluetooth tools.
+Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`). This is what [hm2mqtt](https://github.com/tomquist/hm2mqtt) normally uses as the `deviceId`, and it's shown in the Marstek app and Bluetooth tools.
 
-However, on newer firmware the battery does **not** use its MAC in the cloud
-MQTT topics. Instead it uses a long **encrypted ID** derived from the MAC —
-for example `defa85f58f79ab2d2b2818f0a8cd3ee3` or an even longer string.
-Which form your battery uses depends on the model and firmware version (for
-example HMJ-2 switched with firmware v108, Jupiter/JPLS with v136 — Jupiter C+
-users first noticed this on firmware v142; see the
-[Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md)
-for details). A firmware update can silently switch a battery from MAC to
-encrypted ID — if your battery suddenly stops reacting to commands after an
-update, this is almost certainly why (see [Troubleshooting](#troubleshooting)).
+However, on newer firmware the battery does **not** use its MAC in the cloud MQTT topics. Instead it uses a long **encrypted ID** derived from the MAC — for example `defa85f58f79ab2d2b2818f0a8cd3ee3` or an even longer string. Which form your battery uses depends on the model and firmware version (for example HMJ-2 switched with firmware v108, Jupiter/JPLS with v136 — Jupiter C+ users first noticed this on firmware v142; see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for details). A firmware update can silently switch a battery from MAC to encrypted ID — if your battery suddenly stops reacting to commands after an update, this is almost certainly why (see [Troubleshooting](#troubleshooting)).
 
-Marsrelay forwards the battery's topics as-is, so the ID you found in
-[Step 5](#step-5-find-your-device-information) is whatever the battery uses.
-If that ID is the plain MAC address, you're done — configure it in hm2mqtt and
-skip the rest of this section. If it's an encrypted ID, pick one of the two
-options below.
+Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#step-5-find-your-device-information) is whatever the battery uses. If that ID is the plain MAC address, you're done — configure it in hm2mqtt and skip the rest of this section. If it's an encrypted ID, pick one of the two options below.
 
-> **Batteries configured for local MQTT:** If you configured a B2500 battery
-> to talk to your local MQTT broker directly (e.g. via
-> [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC
-> regardless of firmware version. No encrypted ID handling is needed for such
-> a battery — leave everything as is.
+> **Batteries configured for local MQTT:** If you configured a B2500 battery to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC regardless of firmware version. No encrypted ID handling is needed for such a battery — leave everything as is.
 
 ### Option A: Use the encrypted ID directly in hm2mqtt
 
-The simplest approach: configure the encrypted ID from Step 5 as the
-`deviceId` in hm2mqtt, e.g.
+The simplest approach: configure the encrypted ID from Step 5 as the `deviceId` in hm2mqtt, e.g.
 
 ```yaml
 devices:
@@ -326,9 +305,7 @@ or, for a Docker setup, `DEVICE_0=JPLS-8H:defa85f58f79ab2d2b2818f0a8cd3ee3`.
 
 ### Option B: Let Marsrelay translate between encrypted ID and MAC
 
-Alternatively, keep the familiar Bluetooth MAC in your hm2mqtt configuration
-and have Marsrelay rewrite the ID segment of every topic it forwards. Add an
-`id_mappings` list to the `mosquitto_broker:` block:
+Alternatively, keep the familiar Bluetooth MAC in your hm2mqtt configuration and have Marsrelay rewrite the ID segment of every topic it forwards. Add an `id_mappings` list to the `mosquitto_broker:` block:
 
 ```yaml
 mosquitto_broker:
@@ -339,38 +316,28 @@ mosquitto_broker:
       external: "<bluetooth-mac-address>"
 ```
 
-For each pair, `device` is the encrypted ID that appears in the topic on the
-local mosquitto broker (the one the battery uses for its cloud MQTT topics),
-and `external` is the Bluetooth MAC address that hm2mqtt uses as the device
-ID. Translation is applied in both directions automatically: control messages
-from hm2mqtt on `.../App/<external>/...` are rewritten to
-`.../App/<device>/...` before being delivered to the battery, and status
-messages from the battery on `.../device/<device>/...` are rewritten to
-`.../device/<external>/...` before being forwarded out.
+For each pair, `device` is the encrypted ID that appears in the topic on the local mosquitto broker (the one the battery uses for its cloud MQTT topics), and `external` is the Bluetooth MAC address that hm2mqtt uses as the device ID. Translation is applied in both directions automatically: control messages from hm2mqtt on `.../App/<external>/...` are rewritten to `.../App/<device>/...` before being delivered to the battery, and status messages from the battery on `.../device/<device>/...` are rewritten to `.../device/<external>/...` before being forwarded out.
 
-With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt
-configuration. When you have multiple batteries, make sure each mapping pairs
-the encrypted ID and the MAC of the **same physical battery** (see
-[Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one
-battery if you're unsure which ID belongs to which).
+With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt configuration. When you have multiple batteries, make sure each mapping pairs the encrypted ID and the MAC of the **same physical battery** (see [Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one battery if you're unsure which ID belongs to which).
 
 ### Finding the encrypted ID
 
 Two ways to find out which encrypted ID belongs to which battery:
 
-1. **MQTT Explorer** (no extra software): follow
-   [Step 5](#step-5-find-your-device-information) and wait for the battery to
-   publish on `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. With
-   multiple batteries, power all but one off so you can attribute the ID
-   unambiguously. Remember: ignore `.../App/...` topics — only `/device/`
-   topics come from the battery.
-2. **Hame Relay startup logs**: temporarily install
-   [Hame Relay](https://github.com/tomquist/hame-relay) with your Marstek
-   account credentials. On startup it prints a block per device including the
-   Bluetooth MAC and the derived encrypted ID (the `Remote ID:` line). Since
-   it computes the ID from your account data, this also works before the
-   battery has ever connected to Marsrelay. You can uninstall Hame Relay again
-   afterwards — Marsrelay setups don't need it running.
+1. **MQTT Explorer** (no extra software): follow [Step 5](#step-5-find-your-device-information) and wait for the battery to publish on `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. With multiple batteries, power all but one off so you can attribute the ID unambiguously. Remember: ignore `.../App/...` topics — only `/device/` topics come from the battery.
+2. **Hame Relay startup logs**: temporarily install [Hame Relay](https://github.com/tomquist/hame-relay) with your Marstek account credentials. On startup it prints a block per device including the Bluetooth MAC and the derived encrypted ID (the `Remote ID:` line):
+
+   ```text
+   Device 1:
+     Name: ...
+     Device ID: 009b08a571ee
+     Remote ID: defa85f58f79ab2d2b2818f0a8cd3ee3   <-- the encrypted ID
+     MAC: 009b08a571ee
+     Type: HMJ-2
+     ...
+   ```
+
+   Hame Relay computes the ID from your account's device list, so this works even if the battery never publishes on a `/device/` topic (e.g. because you gave up waiting in Step 5) and even before it has ever connected to Marsrelay. You can uninstall Hame Relay again afterwards — Marsrelay setups don't need it running.
 
 ---
 
@@ -378,56 +345,29 @@ Two ways to find out which encrypted ID belongs to which battery:
 
 ### The battery stopped reacting to commands (e.g. `cd=1`) after a firmware update
 
-Newer firmware switches the battery from using its plain MAC address to an
-[encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics
-(e.g. Jupiter C+ with firmware v142). Marsrelay still forwards everything, but
-hm2mqtt keeps publishing commands to the old MAC-based topic that the battery
-no longer listens on.
+Newer firmware switches the battery from using its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142). Marsrelay still forwards everything, but hm2mqtt keeps publishing commands to the old MAC-based topic that the battery no longer listens on.
 
-**Fix:** find the battery's new encrypted ID (see
-[Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it
-as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your
-setup stays fully offline either way.
+**Fix:** find the battery's new encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
 
 ### No `.../device/...` topic ever appears in MQTT Explorer
 
 Work through this checklist:
 
-1. **Are you looking at the right topics?** Topics under
-   `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data
-   from your battery. Only `.../device/...` topics come from the battery.
-2. **Wait long enough.** The battery can take up to 20 minutes to publish.
-   Keep MQTT Explorer connected the whole time.
-3. **Is the battery really connected to the Marsrelay access point?** The
-   Marstek app sometimes reports a successful WiFi change even though the
-   battery didn't actually connect. Check the Marsrelay logs (web interface or
-   USB): when the battery is connected, you'll see its HTTP requests, e.g.
-   `HTTP GET /app/neng/getDateInfoeu.php`. If those requests appear but no
-   MQTT `/device/` topic does, the battery is connected and the problem is on
-   the MQTT side (see next points).
-4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`,
-   `mqtt_username` and `mqtt_password` in the substitutions, and check the
-   ESPHome logs for MQTT connection errors.
-5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make
-   sure the `psram` settings match your board.
+1. **Are you looking at the right topics?** Topics under `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data from your battery. Only `.../device/...` topics come from the battery.
+2. **Wait long enough.** The battery can take up to 20 minutes to publish. Keep MQTT Explorer connected the whole time.
+3. **Is the battery really connected to the Marsrelay access point?** The Marstek app sometimes reports a successful WiFi change even though the battery didn't actually connect. Check the Marsrelay logs (web interface or USB): when the battery is connected, you'll see its HTTP requests, e.g. `HTTP GET /app/neng/getDateInfoeu.php`. If those requests appear but no MQTT `/device/` topic does, the battery is connected and the problem is on the MQTT side (see next points).
+4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`, `mqtt_username` and `mqtt_password` in the substitutions, and check the ESPHome logs for MQTT connection errors.
+5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make sure the `psram` settings match your board.
+
+If you only need the device ID while you keep debugging, you don't have to wait for the topic: get it from Hame Relay's startup logs instead (see [Finding the encrypted ID](#finding-the-encrypted-id)).
 
 ### hm2mqtt shows all entities as unavailable (or values frozen at old state)
 
-hm2mqtt is waiting for data under a `deviceId` that doesn't match what the
-battery publishes. Compare the ID in the `.../device/<deviceId>/...` topic with
-the `deviceId` configured in hm2mqtt — they must match exactly (or be
-connected via an `id_mappings` entry). See
-[Device IDs](#device-ids-mac-address-vs-encrypted-id).
+hm2mqtt is waiting for data under a `deviceId` that doesn't match what the battery publishes. Compare the ID in the `.../device/<deviceId>/...` topic with the `deviceId` configured in hm2mqtt — they must match exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
 
 ### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
 
-Not with this codebase — it's an ESPHome project. But the concept ports:
-you'd need a WiFi hotspot, a DNS server that resolves every query to the Pi
-itself, an HTTP server implementing the Marstek cloud endpoints (see
-`components/marstack/` for the protocol), and a TLS-enabled MQTT broker on
-port 8883 that bridges to your main broker (see `components/mosquitto_broker/`
-for the topic handling). The [How It Works](#how-it-works) section describes
-how the pieces fit together.
+Not with this codebase — it's an ESPHome project. But the concept ports: you'd need a WiFi hotspot, a DNS server that resolves every query to the Pi itself, an HTTP server implementing the Marstek cloud endpoints (see `components/marstack/` for the protocol), and a TLS-enabled MQTT broker on port 8883 that bridges to your main broker (see `components/mosquitto_broker/` for the topic handling). The [How It Works](#how-it-works) section describes how the pieces fit together.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ flowchart LR
         HomeBroker[Your MQTT broker]
         HM2MQTT[hm2mqtt]
         HA[Home Assistant]
-        Meter[Smart meter / b2500-meter]
+        Meter[Smart meter / AstraMeter]
     end
     Battery -->|DNS lookups| DNS
     Battery -->|HTTP| HTTP
@@ -110,7 +110,7 @@ substitutions:
   mqtt_topic_prefix: "marsrelay"
   # Timezone used to sync the battery clock (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
   timezone: "Europe/Berlin"
-  # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
+  # UDP proxy port for power meter discovery (see https://github.com/tomquist/AstraMeter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   # - Port 2222: Shelly 3EM gen3
@@ -434,7 +434,7 @@ how the pieces fit together.
 ## Optional: Shelly UDP Emulator (Issue #6)
 
 Marsrelay can emulate a Shelly Gen2 energy meter (UDP JSON-RPC) using ESPHome sensor values.
-This is based on the Shelly emulation implemented in <https://github.com/tomquist/b2500-meter>.
+This is based on the Shelly emulation implemented in <https://github.com/tomquist/AstraMeter> (formerly b2500-meter).
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ In MQTT Explorer (connected to your home broker), wait for a message on `marstek
 
 ### 4. Configure hm2mqtt
 
-Enter `deviceType` and `deviceId` in [hm2mqtt](https://github.com/tomquist/hm2mqtt) — done.
+On current firmware the `deviceId` from step 3 is almost always a long **encrypted ID**, not the battery's MAC address. What goes into [hm2mqtt](https://github.com/tomquist/hm2mqtt) depends on the device family:
 
-> **Exception:** if the `deviceId` from step 3 is a long encrypted ID instead of a 12-digit MAC address, read [Device IDs](#device-ids-mac-address-vs-encrypted-id) first. In particular, **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ types) must never get the encrypted ID as hm2mqtt `deviceId`** — they get the Bluetooth MAC plus an `id_mappings` entry in Marsrelay.
+- **B2500/Saturn (HMA/HMB/HMF/HMK/HMJ types):** use the **Bluetooth MAC** as `deviceId` — never the encrypted ID — and add an `id_mappings` entry in Marsrelay. See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+- **Venus, Jupiter and everything else:** use the ID from step 3 as `deviceId`, exactly as it appears in the topic.
+- If the topic shows a plain 12-digit MAC (older firmware, or a B2500 configured for local MQTT): just use that — done.
 
 ## Device IDs: MAC Address vs. Encrypted ID
 
-Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`), shown in the Marstek app and used by [hm2mqtt](https://github.com/tomquist/hm2mqtt) as the `deviceId`. On newer firmware, however, the battery identifies itself in its cloud MQTT topics with a long **encrypted ID** instead — and a firmware update can silently switch a battery from one to the other (see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for which versions).
+Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`), shown in the Marstek app and used by [hm2mqtt](https://github.com/tomquist/hm2mqtt) as the `deviceId`. In its cloud MQTT topics, however, a battery on current firmware identifies itself with a long **encrypted ID** instead — only old firmware still uses the plain MAC there, and a firmware update silently switches a battery over (see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for which versions).
 
-Marsrelay forwards topics as-is, so the ID from step 3 is whatever the battery uses. If it's the plain MAC: configure it in hm2mqtt and you're done. If it's an encrypted ID, follow the section for your device family:
+Marsrelay forwards topics as-is, so the ID from step 3 is whatever the battery uses. In the rare case that it's the plain MAC: configure it in hm2mqtt and you're done. Otherwise, follow the section for your device family:
 
 ### B2500 / Saturn (device types starting with HMA, HMB, HMF, HMK, HMJ)
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Note that the official Marstek app can no longer reach the battery through the c
 
 ## Marsrelay, hm2mqtt and Hame Relay
 
-Three related projects are often mentioned together. They solve different problems:
+Marsrelay is one of three companion projects that each solve a different part of Marstek integration and can be combined as needed:
 
 | Project | Role |
 |---------|------|

--- a/README.md
+++ b/README.md
@@ -182,18 +182,22 @@ mqtt:
   password: ${mqtt_password}
   on_connect:
     - lambda: |-
-        id(mqtt_client).subscribe("marstek_energy/+/App/+/ctrl", [=](const std::string &topic, const std::string &payload) {
-          ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
-          if (topic.find("/App/") == std::string::npos) {
-            ESP_LOGD("MQTT", "Not a control message, skipping");
-            return;
-          }
-          if (topic.find("/ctrl") == std::string::npos) {
-            ESP_LOGD("MQTT", "Not a control message, skipping");
-            return;
-          }
-          id(local_broker).publish_message(topic, payload);
-        });
+        // Batteries use the marstek_energy prefix on newer firmware and the
+        // hame_energy prefix on older firmware; forward commands for both.
+        for (const char *pattern : {"marstek_energy/+/App/+/ctrl", "hame_energy/+/App/+/ctrl"}) {
+          id(mqtt_client).subscribe(pattern, [=](const std::string &topic, const std::string &payload) {
+            ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
+            if (topic.find("/App/") == std::string::npos) {
+              ESP_LOGD("MQTT", "Not a control message, skipping");
+              return;
+            }
+            if (topic.find("/ctrl") == std::string::npos) {
+              ESP_LOGD("MQTT", "Not a control message, skipping");
+              return;
+            }
+            id(local_broker).publish_message(topic, payload);
+          });
+        }
 
 mosquitto_broker:
   id: local_broker
@@ -296,27 +300,17 @@ Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#
 Two rules apply to B2500 devices:
 
 1. **hm2mqtt always gets the Bluetooth MAC as `deviceId` — never the ID from the topic.** hm2mqtt builds its B2500 topics from the configured value itself: it publishes and listens under the plain MAC on `hame_energy/...` topics and under an encrypted variant it derives from the MAC on `marstek_energy/...` topics. Configuring anything other than the MAC breaks this derivation — you can recognize that mistake in the Marsrelay log by extra-long IDs (~96 characters) in the `.../App/.../ctrl` topics. Option A below is therefore **not** available for B2500.
-2. **You will usually also need an `id_mappings` entry in Marsrelay**, because on cloud MQTT — which is what the battery speaks to Marsrelay — a B2500 identifies itself with its cloud identity, not with the plain MAC.
+2. **Add an `id_mappings` entry that maps the battery's topic ID to the Bluetooth MAC**, because on cloud MQTT — which is what the battery speaks to Marsrelay — a B2500 identifies itself with its cloud identity, not with the plain MAC:
 
-What to put into the mapping depends on the prefix of the battery's `/device/` topic from [Step 5](#step-5-find-your-device-information):
+   ```yaml
+   id_mappings:
+     - device: "<id-from-the-battery's-device-topic>"   # from Step 5
+       external: "<bluetooth-mac>"
+   ```
 
-- **Battery publishes under `hame_energy/...` (older firmware):** the ID in the topic is the battery's 24-character cloud device ID. Map it to the MAC:
+Marsrelay handles the rest automatically: it knows hm2mqtt's encrypted MAC variant for B2500 device types and rewrites each topic to whichever form hm2mqtt uses there — the plain MAC on `hame_energy/...` topics, the encrypted variant on `marstek_energy/...` topics. If the battery's topic ID happens to already equal hm2mqtt's encrypted variant, the mapping degrades to a no-op, so adding it is always safe.
 
-  ```yaml
-  id_mappings:
-    - device: "<24-char-id-from-the-device-topic>"
-      external: "<bluetooth-mac>"
-  ```
-
-  Also make sure commands are forwarded for the `hame_energy` prefix — the example config only forwards `marstek_energy` (see [Troubleshooting](#the-battery-doesnt-react-to-commands-eg-cd1), Cause 1).
-
-- **Battery publishes under `marstek_energy/...` (newer firmware):** compare the ID in the battery's `/device/` topic with the ID hm2mqtt publishes commands under on the same prefix — the `marstek_energy/<deviceType>/App/<id>/ctrl` topics you can see in MQTT Explorer or in the Marsrelay log (that ID is hm2mqtt's encrypted variant of the MAC, 32 hex characters). If the two IDs are **identical**, you're done — no mapping needed. If they **differ** (the battery uses an ID that can't be derived from the MAC alone), map the battery's ID to hm2mqtt's:
-
-  ```yaml
-  id_mappings:
-    - device: "<id-from-the-battery's-device-topic>"
-      external: "<id-from-hm2mqtt's-App-topic>"
-  ```
+> This automatic form selection requires a current Marsrelay build from `main`. On older builds, `external` had to be set to the encrypted 32-hex ID from hm2mqtt's `marstek_energy/.../App/.../ctrl` topics manually for batteries on that prefix — such configs keep working unchanged.
 
 > **B2500 configured for local MQTT:** If you configured your B2500 to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it doesn't use its cloud identity — it publishes under the plain MAC on `hame_energy/...` topics, which matches hm2mqtt directly. Use the MAC in hm2mqtt; no mapping is needed.
 
@@ -380,7 +374,7 @@ Two ways to find out which encrypted ID belongs to which battery:
 
 Marsrelay's log shows `Received control message: ...` but the battery never answers. The command is reaching Marsrelay, but it doesn't match the topic the battery actually listens on. There are two common causes — compare the `.../device/<deviceId>/...` topic the battery publishes on (see [Step 5](#step-5-find-your-device-information)) with the topic your commands arrive on:
 
-**Cause 1: Wrong topic prefix (`hame_energy` vs. `marstek_energy`).** Batteries use one of two cloud topic prefixes depending on their firmware generation: older firmware talks to the 2024-generation cloud broker using `hame_energy/...`, newer firmware to the 2025 generation using `marstek_energy/...`. The example configuration only forwards commands for `marstek_energy/+/App/+/ctrl`. If your battery's `/device/` topics appear under `hame_energy/...`, subscribe to that prefix as well (or instead) in the `mqtt.on_connect` lambda:
+**Cause 1: Wrong topic prefix (`hame_energy` vs. `marstek_energy`).** Batteries use one of two cloud topic prefixes depending on their firmware generation: older firmware talks to the 2024-generation cloud broker using `hame_energy/...`, newer firmware to the 2025 generation using `marstek_energy/...`. The current example configuration forwards commands for both prefixes, but configs created from an older version of the example only subscribe `marstek_energy/+/App/+/ctrl`. If your battery's `/device/` topics appear under `hame_energy/...`, make sure that prefix is subscribed as well in the `mqtt.on_connect` lambda:
 
 ```yaml
 mqtt:
@@ -399,7 +393,7 @@ The outgoing direction needs no change: the `mosquitto_broker` `on_message` forw
 **Cause 2: The device ID in the topic doesn't match what hm2mqtt publishes to.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142), so this often shows up right after a firmware update. The fix depends on the device family:
 
 - **Venus/Jupiter and other non-B2500 devices:** find the battery's encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
-- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** keep the **Bluetooth MAC** as the `deviceId` in hm2mqtt and add an `id_mappings` entry that connects the battery's topic ID to the ID hm2mqtt publishes under — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for exactly which value goes where. If you pasted the battery's topic ID into hm2mqtt instead, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log).
+- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** keep the **Bluetooth MAC** as the `deviceId` in hm2mqtt and add an `id_mappings` entry mapping the battery's topic ID to that MAC (see [Device IDs](#device-ids-mac-address-vs-encrypted-id); requires a current Marsrelay build). If you pasted the battery's topic ID into hm2mqtt instead, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log).
 
 ### No `.../device/...` topic ever appears in MQTT Explorer
 
@@ -441,7 +435,7 @@ Workaround: bring the meter reading into ESPHome as a sensor (for example import
 
 ### hm2mqtt shows all entities as unavailable (or values frozen at old state)
 
-hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC and the battery's topic ID usually needs an `id_mappings` entry on top; for all other devices the configured ID must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC, with an `id_mappings` entry mapping the battery's topic ID to that MAC; for all other devices the configured ID must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
 
 ### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
 

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If nothing has appeared after 20 minutes, you don't have to keep waiting: you ca
 
 Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://github.com/tomquist/hm2mqtt) configuration file. Your Marstek Energy Storage system is now integrated with your home automation!
 
-> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, you can either use it directly in hm2mqtt or keep using the Bluetooth MAC and let Marsrelay translate — see [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, what to put into hm2mqtt depends on your device family — B2500/Saturn devices always get the Bluetooth MAC, other devices get the encrypted ID (or an ID mapping). Read [Device IDs](#device-ids-mac-address-vs-encrypted-id) before continuing.
 
 ---
 
@@ -289,23 +289,33 @@ Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b
 
 However, on newer firmware the battery does **not** use its MAC in the cloud MQTT topics. Instead it uses a long **encrypted ID** derived from the MAC — for example `defa85f58f79ab2d2b2818f0a8cd3ee3` or an even longer string. Which form your battery uses depends on the model and firmware version (for example HMJ-2 switched with firmware v108, Jupiter/JPLS with v136 — Jupiter C+ users first noticed this on firmware v142; see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for details). A firmware update can silently switch a battery from MAC to encrypted ID — if your battery suddenly stops reacting to commands after an update, this is almost certainly why (see [Troubleshooting](#troubleshooting)).
 
-Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#step-5-find-your-device-information) is whatever the battery uses. If that ID is the plain MAC address, you're done — configure it in hm2mqtt and skip the rest of this section. If it's an encrypted ID, pick one of the two options below.
+Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#step-5-find-your-device-information) is whatever the battery uses. If that ID is the plain MAC address, you're done — configure it in hm2mqtt and skip the rest of this section. If it's an encrypted ID, what to configure **depends on the device family**, because hm2mqtt treats them differently.
 
-> **Batteries configured for local MQTT:** If you configured a B2500 battery to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC regardless of firmware version. No encrypted ID handling is needed for such a battery — leave everything as is.
+### B2500 / Saturn (device types starting with HMA, HMB, HMF, HMK, HMJ)
 
-### Option A: Use the encrypted ID directly in hm2mqtt
+Configure the **Bluetooth MAC** as the `deviceId` in hm2mqtt — even though the topics show an encrypted ID. hm2mqtt knows the B2500 encryption scheme and derives the encrypted topic ID from the MAC by itself, so its topics match the battery automatically. No `id_mappings` in Marsrelay are needed.
+
+Do **not** paste the encrypted ID from the `/device/` topic into hm2mqtt: hm2mqtt would encrypt it a *second* time and publish commands to a nonsense topic that the battery never sees. You can recognize this mistake in the Marsrelay log by extra-long IDs (~96 characters instead of 32) in the `.../App/.../ctrl` topics.
+
+> **B2500 configured for local MQTT:** If you configured your B2500 to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC regardless of firmware version. Same conclusion: use the MAC in hm2mqtt, and no ID handling is needed.
+
+### Venus, Jupiter and all other device types (VNS…, JPLS…, HMG…, HMM…, …)
+
+For these devices hm2mqtt uses the configured `deviceId` exactly as-is, and their encrypted ID cannot be computed from the MAC alone (it also depends on a per-device salt that only exists in your Marstek cloud account). So you have two options:
+
+#### Option A: Use the encrypted ID directly in hm2mqtt
 
 The simplest approach: configure the encrypted ID from Step 5 as the `deviceId` in hm2mqtt, e.g.
 
 ```yaml
 devices:
   - deviceType: "JPLS-8H"
-    deviceId: "defa85f58f79ab2d2b2818f0a8cd3ee3"
+    deviceId: "<encrypted-id-from-the-device-topic>"
 ```
 
-or, for a Docker setup, `DEVICE_0=JPLS-8H:defa85f58f79ab2d2b2818f0a8cd3ee3`.
+or, for a Docker setup, `DEVICE_0=JPLS-8H:<encrypted-id-from-the-device-topic>`.
 
-### Option B: Let Marsrelay translate between encrypted ID and MAC
+#### Option B: Let Marsrelay translate between encrypted ID and MAC
 
 Alternatively, keep the familiar Bluetooth MAC in your hm2mqtt configuration and have Marsrelay rewrite the ID segment of every topic it forwards. Add an `id_mappings` list to the `mosquitto_broker:` block:
 
@@ -323,6 +333,8 @@ For each pair, `device` is the encrypted ID that appears in the topic on the loc
 With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt configuration. When you have multiple batteries, make sure each mapping pairs the encrypted ID and the MAC of the **same physical battery** (see [Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one battery if you're unsure which ID belongs to which).
 
 ### Finding the encrypted ID
+
+(You only need this for Venus/Jupiter and the other non-B2500 device types — for B2500/Saturn devices the Bluetooth MAC is all you need, see above.)
 
 Two ways to find out which encrypted ID belongs to which battery:
 
@@ -365,7 +377,10 @@ mqtt:
 
 The outgoing direction needs no change: the `mosquitto_broker` `on_message` forwarding matches any topic containing `/device/`, regardless of prefix.
 
-**Cause 2: The device ID changed to an encrypted ID after a firmware update.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142). hm2mqtt then keeps publishing commands to the old MAC-based topic that the battery no longer listens on. **Fix:** find the battery's new encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
+**Cause 2: The device ID in the topic doesn't match what hm2mqtt publishes to.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142), so this often shows up right after a firmware update. The fix depends on the device family:
+
+- **Venus/Jupiter and other non-B2500 devices:** find the battery's encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
+- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** configure the **Bluetooth MAC** as the `deviceId` — hm2mqtt derives the encrypted ID itself. If you pasted the encrypted ID from the topic into hm2mqtt, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
 
 ### No `.../device/...` topic ever appears in MQTT Explorer
 
@@ -407,7 +422,7 @@ Workaround: bring the meter reading into ESPHome as a sensor (for example import
 
 ### hm2mqtt shows all entities as unavailable (or values frozen at old state)
 
-hm2mqtt is waiting for data under a `deviceId` that doesn't match what the battery publishes. Compare the ID in the `.../device/<deviceId>/...` topic with the `deviceId` configured in hm2mqtt — they must match exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC (hm2mqtt derives the encrypted topic ID from it), for all other devices it must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
 
 ### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,20 @@
 # Marsrelay
 
-Marsrelay is a simple device that lets you use your Marstek Energy Storage system completely offline while still integrating it with your home automation setup.
+Marsrelay runs your Marstek Energy Storage system **completely offline**: a small ESP32-S3 device emulates the Marstek cloud locally, so the battery works without internet while all data and controls flow into your home automation via MQTT.
 
-## What is Marsrelay?
-
-Marsrelay replaces the Marstek cloud service with a small device that runs locally in your home. Instead of your Marstek battery system connecting to the internet, it connects to Marsrelay, which then connects to your home automation system.
-
-## Why Use Marsrelay?
-
-- **Works Offline**: Your Marstek system doesn't need internet access
-- **Privacy**: All data stays in your home network
-- **Home Automation Integration**: Connect your Marstek system to home automation projects like [hm2mqtt](https://github.com/tomquist/hm2mqtt)
-- **No Cloud Dependencies**: No need to rely on Marstek's cloud services
-- **No Device Hacking Required**: The best part? You don't need to modify or hack your Marstek Energy Storage device at all. The only thing you need to do is configure your device to connect to Marsrelay's WiFi access point instead of your regular WiFi network.
+- **No cloud, no internet** — all data stays in your home network
+- **No device hacking** — you only point the battery's WiFi at Marsrelay's access point
+- **Home Assistant integration** via [hm2mqtt](https://github.com/tomquist/hm2mqtt)
 
 ## How It Works
 
-Marstek batteries talk to two cloud services: an HTTP API (date/time sync and similar requests) and an MQTT broker (telemetry and control). Marsrelay emulates both on a single ESP32-S3, so the battery behaves exactly as if it were online:
+Marstek batteries talk to two cloud services: an HTTP API and an MQTT broker. Marsrelay emulates both on one ESP32-S3:
 
-1. **Creates a WiFi Network** (`wifi` component): Marsrelay opens its own WiFi access point that your Marstek device connects to, while at the same time staying connected to your home WiFi as a regular client
-2. **Redirects Internet Requests** (`capture_dns` component): When the battery looks up any Marstek cloud hostname via DNS, Marsrelay answers with its own IP address, so all cloud traffic ends up at the ESP32
-3. **Acts Like Marstek's HTTP Server** (`marstack` component): A web server responds to the Marstek cloud HTTP endpoints the battery calls (for example `GET /app/neng/getDateInfoeu.php`, which the battery uses to sync its clock), so the battery believes it is talking to the real cloud
-4. **Acts Like Marstek's MQTT Broker** (`mosquitto_broker` component): An embedded TLS MQTT broker (port 8883) accepts the battery's cloud MQTT connection and bridges it to your home network:
-   - Messages the battery publishes on `marstek_energy/<deviceType>/device/<deviceId>/...` (or `hame_energy/...` on older firmware) are forwarded to your home MQTT broker
-   - Control messages published on your home broker under `marstek_energy/<deviceType>/App/<deviceId>/ctrl` (for example by [hm2mqtt](https://github.com/tomquist/hm2mqtt)) are delivered back to the battery
-5. **Bridges Power Meter Traffic** (`udp_proxy` component): UDP broadcasts used for power meter discovery and zero feed-in control are relayed between the battery's network and your home network
+1. **WiFi access point** (`wifi`): the battery connects to it, while Marsrelay stays connected to your home WiFi
+2. **DNS capture** (`capture_dns`): every cloud hostname lookup is answered with Marsrelay's own IP
+3. **Cloud HTTP emulation** (`marstack`): answers the Marstek cloud endpoints the battery calls (e.g. clock sync via `getDateInfoeu.php`)
+4. **Cloud MQTT emulation** (`mosquitto_broker`): a TLS broker on port 8883 accepts the battery's cloud MQTT connection — battery data (`.../device/...` topics) is forwarded to your home broker, commands (`.../App/.../ctrl`) are relayed back
+5. **UDP proxy** (`udp_proxy`): bridges power meter broadcasts between both networks for zero feed-in
 
 ```mermaid
 flowchart LR
@@ -32,9 +22,9 @@ flowchart LR
         Battery[Marstek battery]
     end
     subgraph ESP["Marsrelay (ESP32-S3)"]
-        DNS[capture_dns<br/>DNS redirection]
-        HTTP[marstack<br/>cloud HTTP emulation]
-        Broker[mosquitto_broker<br/>cloud MQTT emulation]
+        DNS[capture_dns]
+        HTTP[marstack]
+        Broker[mosquitto_broker]
         UDP[udp_proxy]
     end
     subgraph Home["Home network"]
@@ -43,412 +33,101 @@ flowchart LR
         HA[Home Assistant]
         Meter[Smart meter / AstraMeter]
     end
-    Battery -->|DNS lookups| DNS
+    Battery -->|DNS| DNS
     Battery -->|HTTP| HTTP
     Battery <-->|MQTT over TLS| Broker
-    Battery <-.->|UDP broadcasts| UDP
+    Battery <-.->|UDP| UDP
     UDP <-.-> Meter
-    Broker <-->|forwards both directions| HomeBroker
+    Broker <--> HomeBroker
     HomeBroker <--> HM2MQTT
     HM2MQTT <--> HA
 ```
 
-## The Result
+The battery thinks it's online; the Marstek app keeps working via Bluetooth only. You still need **hm2mqtt** on top — Marsrelay only moves raw MQTT messages, hm2mqtt parses them and creates the Home Assistant entities. **[Hame Relay](https://github.com/tomquist/hame-relay)** is *not* needed: it bridges the real cloud, which an offline setup doesn't have.
 
-Your Marstek Energy Storage system operates completely offline, thinking it's connected to Marstek's cloud, while all its data and controls are available to your home automation system through MQTT.
+## Setup
 
-Note that the official Marstek app can no longer reach the battery through the cloud in this setup — that's the point of going offline. You can still use the app via Bluetooth when you are near the battery.
+You need: an ESP32-S3 board ([single](https://amzn.to/429OJDX) with "octal" PSRAM, [3-pack](https://amzn.to/3PwGRVv), [3-pack mini](https://amzn.to/4qIjp8P) with "quad" PSRAM), [ESPHome](https://esphome.io/) (e.g. the Home Assistant add-on), an MQTT broker, and [MQTT Explorer](https://github.com/thomasnordquist/MQTT-Explorer).
 
-## Marsrelay, hm2mqtt and Hame Relay
+### 1. Flash Marsrelay
 
-Marsrelay is one of three companion projects that each solve a different part of Marstek integration and can be combined as needed:
+Download [`marsrelay_esp32s3.yaml`](marsrelay_esp32s3.yaml) and adjust the `substitutions:` block at the top:
 
-| Project | Role |
-|---------|------|
-| **Marsrelay** (this project) | Replaces the Marstek **cloud** locally. Batteries connect to it over WiFi; it forwards their raw MQTT messages to your home broker. Runs on an ESP32-S3. |
-| **[hm2mqtt](https://github.com/tomquist/hm2mqtt)** | Parses the raw battery MQTT messages and integrates them with Home Assistant (auto-discovery, sensors, controls). Runs as a Home Assistant add-on or Docker container. |
-| **[Hame Relay](https://github.com/tomquist/hame-relay)** | Bridges MQTT between the **real** Marstek cloud and your local broker, for setups where the battery stays cloud-connected. |
+- **`wifi_ssid` / `wifi_password`**: your home WiFi
+- **`ap_ssid` / `ap_password`**: the WiFi network your battery will connect to
+- **`mqtt_broker` / `mqtt_username` / `mqtt_password`**: your home MQTT broker
+- **`timezone`**: used to keep the battery clock in sync ([timezone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones))
+- **`udp_proxy_port`**: depends on your power meter / firmware (see the comment in the file)
+- **`psram`**: must match your board ([details](https://esphome.io/components/psram/))
 
-In a Marsrelay setup:
+Then build and flash it with ESPHome.
 
-- **You still need hm2mqtt.** Marsrelay only moves raw MQTT messages; it doesn't parse them or create Home Assistant entities. hm2mqtt works the same whether the data arrives via Marsrelay or via Hame Relay.
-- **You don't need Hame Relay.** With Marsrelay the battery never talks to the real cloud, so there is nothing to bridge. The one exception: temporarily installing Hame Relay is a convenient way to look up a battery's encrypted device ID (see [Device IDs](#device-ids-mac-address-vs-encrypted-id) below) — you can uninstall it again afterwards.
+### 2. Connect the battery
 
----
+In the battery's WiFi settings, connect it to the Marsrelay access point (`ap_ssid` / `ap_password`). That's all the battery-side setup — no hacks, no firmware modification.
 
-## Getting Started
+### 3. Find your device information
 
-### Prerequisites
+In MQTT Explorer (connected to your home broker), wait for a message on `marstek_energy/<deviceType>/device/<deviceId>/ctrl` — or `hame_energy/...` on older firmware. **This can take up to 20 minutes.** Note down `deviceType` and `deviceId`.
 
-- ESPHome installed (e.g., via the ESPHome addon in Home Assistant)
-- An MQTT broker running on your network
-- A tool like [MQTT Explorer](https://github.com/thomasnordquist/MQTT-Explorer) to monitor MQTT messages
+- Ignore `.../App/...` topics — those are commands *sent by* hm2mqtt, not by your battery.
+- Nothing appearing? See [troubleshooting](docs/troubleshooting.md#no-device-topic-ever-appears). You can also read the ID from Hame Relay's startup logs instead of waiting (see [finding the encrypted ID](#finding-the-encrypted-id)).
 
-### Step 0: Get an ESP32-S3 Board
+### 4. Configure hm2mqtt
 
-You'll need an ESP32-S3 development board. You can purchase one here:
+Enter `deviceType` and `deviceId` in [hm2mqtt](https://github.com/tomquist/hm2mqtt) — done.
 
-- Single board: [Amazon](https://amzn.to/429OJDX) with "octal" PSRAM
-- 3-pack (better value): [Amazon](https://amzn.to/3PwGRVv)
-- 3-pack mini: [Amazon](https://amzn.to/4qIjp8P) with "quad" PSRAM
-
-### Step 1: Configure ESPHome
-
-Copy the following ESPHome configuration and save it as `marsrelay_esp32s3.yaml`.
-
-```yaml
-substitutions:
-  device_name: marsrelay-esp32s3
-  friendly_name: Marsrelay ESP32S3
-  wifi_ssid: "your-home-wifi-ssid"
-  wifi_password: "your-home-wifi-password"
-  ap_ssid: "marsrelay"
-  ap_password: "marsrelay"
-  mqtt_broker: 192.168.1.100
-  mqtt_username: ""
-  mqtt_password: ""
-  mqtt_topic_prefix: "marsrelay"
-  # Timezone used to sync the battery clock (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-  timezone: "Europe/Berlin"
-  # UDP proxy port for power meter discovery (see https://github.com/tomquist/AstraMeter)
-  # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
-  # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
-  # - Port 2222: Shelly 3EM gen3
-  # - Port 2223: Shelly Pro EM50
-  # - Port 12345: CT001/CT002/CT003
-  udp_proxy_port: "1010"
-  psram:
-    # Set to true if your ESP32S3 has PSRAM.
-    enabled: true
-    # This needs to be set correctly! See https://esphome.io/components/psram/ for more information.
-    mode: quad
-
-esphome:
-  name: ${device_name}
-  friendly_name: ${friendly_name}
-
-psram:
-  mode: ${psram.mode}
-  disabled: ${false if psram.enabled else true}
-
-esp32:
-  board: esp32-s3-devkitc-1
-  variant: esp32s3
-  framework:
-    type: esp-idf
-    sdkconfig_options:
-      CONFIG_LWIP_IPV6: y
-      CONFIG_ESP_TLS_INSECURE: y  # Allow skipping certificate verification
-      CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY: y  # Skip server certificate verification
-      CONFIG_LWIP_MAX_SOCKETS: "58"  # Reduced from 64 to ensure LWIP_SOCKET_OFFSET >= 6 (FD_SETSIZE=64, so offset = 64-58=6)
-      CONFIG_LWIP_TCP_MSL: "30"  # Reduce TIME_WAIT timeout from default 60s to 30s (in seconds)
-      CONFIG_LWIP_SOCKET_OFFSET: "6"  # Required for esp_vfs_console compatibility (must be >= 6 for esp_vfs_console)
-
-external_components:
-  - source:
-      type: git
-      url: https://github.com/tomquist/marsrelay
-      ref: main
-
-logger:
-
-# Keeps the ESP32 system clock in sync so the marstack component serves the
-# correct date/time to the battery (GET /app/neng/getDateInfoeu.php).
-time:
-  - platform: sntp
-    id: sntp_time
-    timezone: ${timezone}
-
-wifi:
-  ssid: ${wifi_ssid}
-  password: ${wifi_password}
-  ap:
-    ssid: ${ap_ssid}
-    password: ${ap_password}
-  use_psram: ${psram.enabled}
-
-capture_dns:
-  id: capture_dns_server
-
-# UDP proxy bridges broadcasts between AP and STA networks for power meter discovery
-# Add multiple entries if you need to support different firmware versions
-udp_proxy:
-  - port: ${udp_proxy_port}
-
-mqtt:
-  id: mqtt_client
-  broker: ${mqtt_broker}
-  username: ${mqtt_username}
-  password: ${mqtt_password}
-  on_connect:
-    - lambda: |-
-        // Batteries use the marstek_energy prefix on newer firmware and the
-        // hame_energy prefix on older firmware; forward commands for both.
-        for (const char *pattern : {"marstek_energy/+/App/+/ctrl", "hame_energy/+/App/+/ctrl"}) {
-          id(mqtt_client).subscribe(pattern, [=](const std::string &topic, const std::string &payload) {
-            ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
-            if (topic.find("/App/") == std::string::npos) {
-              ESP_LOGD("MQTT", "Not a control message, skipping");
-              return;
-            }
-            if (topic.find("/ctrl") == std::string::npos) {
-              ESP_LOGD("MQTT", "Not a control message, skipping");
-              return;
-            }
-            id(local_broker).publish_message(topic, payload);
-          });
-        }
-
-mosquitto_broker:
-  id: local_broker
-  tls: true
-  tls_skip_verification: true
-  port: 8883
-  max_clients: 5
-  on_message:
-    # Only forward messages containing /device/
-    - if:
-        condition:
-          lambda: 'return topic.find("/device/") != std::string::npos;'
-        then:
-          - mqtt.publish:
-              topic: !lambda |-
-                return topic;
-              payload: !lambda |-
-                return payload;
-
-web_server:
-  port: 80
-  version: 3
-
-marstack:
-  id: marstack_http
-  on_request:
-    - logger.log:
-        format: "HTTP %s %s body=%s"
-        args: [method.c_str(), url.c_str(), body.c_str()]
-    - mqtt.publish:
-        topic: ${mqtt_topic_prefix}/request
-        payload: !lambda |-
-          return json::build_json([&](JsonObject root) {
-            root["source_ip"] = source_ip;
-            root["url"] = url;
-            root["method"] = method;
-            root["body"] = body;
-          });
-```
-
-### Step 2: Adjust Configuration Values
-
-Edit the `substitutions` section at the top of the configuration file:
-
-- **`wifi_ssid`** and **`wifi_password`**: Your home WiFi network credentials (so Marsrelay can connect to your network)
-- **`ap_ssid`** and **`ap_password`**: The WiFi network name and password that your Marstek device will connect to (default is "marsrelay" / "marsrelay")
-- **`mqtt_broker`**: The IP address of your MQTT broker (e.g., `192.168.1.100`)
-- **`mqtt_username`** and **`mqtt_password`**: Your MQTT broker credentials (leave empty if not required)
-- **`timezone`**: Your local timezone (e.g. `Europe/Berlin`). Marsrelay uses this to keep the battery's clock in sync; if it's wrong the battery time will be off. See the [list of timezones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
-- **`psram.enabled`** and **`psram.mode`**: Set according to your ESP32-S3 board specifications
-
-### Step 3: Build and Flash
-
-1. Open ESPHome (e.g., via the Home Assistant ESPHome addon)
-2. Upload the configuration file
-3. Build the firmware image
-4. Flash the image to your ESP32-S3 device
-
-### Step 4: Configure Your Marstek Energy Storage Device
-
-1. On your Marstek Energy Storage device, go to the WiFi/Network settings
-2. Configure it to connect to the access point named "marsrelay" (or whatever you set as `ap_ssid`)
-3. Enter the password you configured (default is "marsrelay")
-4. Save the configuration
-
-**That's it!** No hacking, no firmware modifications, no complicated setup. Just change the WiFi network your Marstek device connects to.
-
-### Step 5: Find Your Device Information
-
-1. Open MQTT Explorer (or another MQTT client) and connect to your MQTT broker
-2. Wait for a message to appear on the topic: `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. The battery publishes on its own schedule — **this can take up to 20 minutes**, so keep MQTT Explorer connected and be patient
-3. Note down the **`deviceType`** and **`deviceId`** from the topic
-
-> **Check both topic prefixes.** Depending on its firmware generation, the battery uses either `marstek_energy/...` or the older `hame_energy/...` prefix for its cloud topics, so the `/device/` topic may appear under either one. If your battery uses `hame_energy`, one config adjustment is needed so commands reach it — see [Troubleshooting](#the-battery-doesnt-react-to-commands-eg-cd1).
-
-> **Only topics containing `/device/` come from your battery.** You will likely also see topics like `marstek_energy/<deviceType>/App/<id>/ctrl` — these are control messages *sent by* hm2mqtt (or the app), not by your battery. They tell you nothing about your battery's device ID, so ignore them in this step.
-
-Depending on the battery's firmware version, the `deviceId` in the topic is either the battery's Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`) or a much longer encrypted ID. Both are normal — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for what this means for your hm2mqtt configuration.
-
-If nothing has appeared after 20 minutes, you don't have to keep waiting: you can look the device ID up via Hame Relay instead — temporarily install it with your Marstek account credentials and read the ID from its startup logs (see [Finding the encrypted ID](#finding-the-encrypted-id) for the details). Also work through [Troubleshooting](#troubleshooting), because a missing `/device/` topic usually means the battery isn't sending data yet — knowing the ID alone won't fix that.
-
-### Step 6: Configure hm2mqtt
-
-Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://github.com/tomquist/hm2mqtt) configuration file. Your Marstek Energy Storage system is now integrated with your home automation!
-
-> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, what to put into hm2mqtt depends on your device family — B2500/Saturn devices always get the Bluetooth MAC (usually combined with an `id_mappings` entry in Marsrelay), other devices get the encrypted ID directly (or the MAC plus a mapping). Read [Device IDs](#device-ids-mac-address-vs-encrypted-id) before continuing.
-
----
+> **Exception:** if the `deviceId` from step 3 is a long encrypted ID instead of a 12-digit MAC address, read [Device IDs](#device-ids-mac-address-vs-encrypted-id) first. In particular, **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ types) must never get the encrypted ID as hm2mqtt `deviceId`** — they get the Bluetooth MAC plus an `id_mappings` entry in Marsrelay.
 
 ## Device IDs: MAC Address vs. Encrypted ID
 
-Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`). This is what [hm2mqtt](https://github.com/tomquist/hm2mqtt) normally uses as the `deviceId`, and it's shown in the Marstek app and Bluetooth tools.
+Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`), shown in the Marstek app and used by [hm2mqtt](https://github.com/tomquist/hm2mqtt) as the `deviceId`. On newer firmware, however, the battery identifies itself in its cloud MQTT topics with a long **encrypted ID** instead — and a firmware update can silently switch a battery from one to the other (see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for which versions).
 
-However, on newer firmware the battery does **not** use its MAC in the cloud MQTT topics. Instead it uses a long **encrypted ID** derived from the MAC — for example `defa85f58f79ab2d2b2818f0a8cd3ee3` or an even longer string. Which form your battery uses depends on the model and firmware version (for example HMJ-2 switched with firmware v108, Jupiter/JPLS with v136 — Jupiter C+ users first noticed this on firmware v142; see the [Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md) for details). A firmware update can silently switch a battery from MAC to encrypted ID — if your battery suddenly stops reacting to commands after an update, this is almost certainly why (see [Troubleshooting](#troubleshooting)).
-
-Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#step-5-find-your-device-information) is whatever the battery uses. If that ID is the plain MAC address, you're done — configure it in hm2mqtt and skip the rest of this section. If it's an encrypted ID, what to configure **depends on the device family**, because hm2mqtt treats them differently.
+Marsrelay forwards topics as-is, so the ID from step 3 is whatever the battery uses. If it's the plain MAC: configure it in hm2mqtt and you're done. If it's an encrypted ID, follow the section for your device family:
 
 ### B2500 / Saturn (device types starting with HMA, HMB, HMF, HMK, HMJ)
 
-Two rules apply to B2500 devices:
+- **hm2mqtt:** `deviceId` = the **Bluetooth MAC**, never the ID from the topic. hm2mqtt derives its own topic IDs from this value; pasting the topic ID instead sends commands to dead, double-encrypted topics (recognizable as ~96-character IDs in the Marsrelay log).
+- **Marsrelay:** map the battery's topic ID to the MAC:
 
-1. **hm2mqtt always gets the Bluetooth MAC as `deviceId` — never the ID from the topic.** hm2mqtt builds its B2500 topics from the configured value itself: it publishes and listens under the plain MAC on `hame_energy/...` topics and under an encrypted variant it derives from the MAC on `marstek_energy/...` topics. Configuring anything other than the MAC breaks this derivation — you can recognize that mistake in the Marsrelay log by extra-long IDs (~96 characters) in the `.../App/.../ctrl` topics. Option A below is therefore **not** available for B2500.
-2. **Add an `id_mappings` entry that maps the battery's topic ID to the Bluetooth MAC**, because on cloud MQTT — which is what the battery speaks to Marsrelay — a B2500 identifies itself with its cloud identity, not with the plain MAC:
+  ```yaml
+  mosquitto_broker:
+    # ...existing options...
+    id_mappings:
+      - device: "<id-from-the-device-topic>"   # from step 3
+        external: "<bluetooth-mac>"
+  ```
 
-   ```yaml
-   id_mappings:
-     - device: "<id-from-the-battery's-device-topic>"   # from Step 5
-       external: "<bluetooth-mac>"
-   ```
+Marsrelay rewrites the IDs in both directions and automatically uses the form hm2mqtt expects per topic (plain MAC on `hame_energy/...`, hm2mqtt's encrypted variant on `marstek_energy/...`). The mapping is a harmless no-op when the IDs already match, so just always add it. Requires a current build from `main`; older configs that set the encrypted variant as `external` manually keep working.
 
-Marsrelay handles the rest automatically: it knows hm2mqtt's encrypted MAC variant for B2500 device types and rewrites each topic to whichever form hm2mqtt uses there — the plain MAC on `hame_energy/...` topics, the encrypted variant on `marstek_energy/...` topics. If the battery's topic ID happens to already equal hm2mqtt's encrypted variant, the mapping degrades to a no-op, so adding it is always safe.
-
-> This automatic form selection requires a current Marsrelay build from `main`. On older builds, `external` had to be set to the encrypted 32-hex ID from hm2mqtt's `marstek_energy/.../App/.../ctrl` topics manually for batteries on that prefix — such configs keep working unchanged.
-
-> **B2500 configured for local MQTT:** If you configured your B2500 to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it doesn't use its cloud identity — it publishes under the plain MAC on `hame_energy/...` topics, which matches hm2mqtt directly. Use the MAC in hm2mqtt; no mapping is needed.
+> Exception: a B2500 configured for **local MQTT** (e.g. via [hmjs](https://tomquist.github.io/hmjs/)) publishes under its plain MAC — MAC in hm2mqtt, no mapping needed.
 
 ### Venus, Jupiter and all other device types (VNS…, JPLS…, HMG…, HMM…, …)
 
-For these devices hm2mqtt uses the configured `deviceId` exactly as-is, and their encrypted ID cannot be computed from the MAC alone (it also depends on a per-device salt that only exists in your Marstek cloud account). So you have two options:
+hm2mqtt uses the configured `deviceId` as-is for these devices, so pick one of two options:
 
-#### Option A: Use the encrypted ID directly in hm2mqtt
+- **Option A — encrypted ID in hm2mqtt (simplest):** configure the ID from step 3 as the `deviceId`, e.g. `DEVICE_0=JPLS-8H:<encrypted-id-from-the-device-topic>`.
+- **Option B — MAC plus mapping:** keep the Bluetooth MAC as `deviceId` in hm2mqtt and add the same `id_mappings` entry as above (`device:` the encrypted ID, `external:` the MAC).
 
-The simplest approach: configure the encrypted ID from Step 5 as the `deviceId` in hm2mqtt, e.g.
-
-```yaml
-devices:
-  - deviceType: "JPLS-8H"
-    deviceId: "<encrypted-id-from-the-device-topic>"
-```
-
-or, for a Docker setup, `DEVICE_0=JPLS-8H:<encrypted-id-from-the-device-topic>`.
-
-#### Option B: Let Marsrelay translate between encrypted ID and MAC
-
-Alternatively, keep the familiar Bluetooth MAC in your hm2mqtt configuration and have Marsrelay rewrite the ID segment of every topic it forwards. Add an `id_mappings` list to the `mosquitto_broker:` block:
-
-```yaml
-mosquitto_broker:
-  id: local_broker
-  # ...existing options...
-  id_mappings:
-    - device: "<encrypted-id-from-the-device-topic>"
-      external: "<bluetooth-mac-address>"
-```
-
-For each pair, `device` is the encrypted ID that appears in the topic on the local mosquitto broker (the one the battery uses for its cloud MQTT topics), and `external` is the Bluetooth MAC address that hm2mqtt uses as the device ID. Translation is applied in both directions automatically: control messages from hm2mqtt on `.../App/<external>/...` are rewritten to `.../App/<device>/...` before being delivered to the battery, and status messages from the battery on `.../device/<device>/...` are rewritten to `.../device/<external>/...` before being forwarded out.
-
-With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt configuration. When you have multiple batteries, make sure each mapping pairs the encrypted ID and the MAC of the **same physical battery** (see [Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one battery if you're unsure which ID belongs to which).
+With multiple batteries, make sure each mapping pairs the IDs of the **same physical battery** — see [Finding the encrypted ID](#finding-the-encrypted-id).
 
 ### Finding the encrypted ID
 
-Two ways to find out which encrypted ID belongs to which battery:
-
-1. **MQTT Explorer** (no extra software): follow [Step 5](#step-5-find-your-device-information) and wait for the battery to publish on `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. With multiple batteries, power all but one off so you can attribute the ID unambiguously. Remember: ignore `.../App/...` topics — only `/device/` topics come from the battery.
-2. **Hame Relay startup logs**: temporarily install [Hame Relay](https://github.com/tomquist/hame-relay) with your Marstek account credentials. On startup it prints a block per device including the Bluetooth MAC and the derived encrypted ID (the `Remote ID:` line):
+1. **MQTT Explorer:** wait for the battery's `.../device/<deviceId>/ctrl` topic (step 3, up to 20 minutes). With multiple batteries, power all but one off to attribute the IDs unambiguously.
+2. **Hame Relay startup logs:** temporarily install [Hame Relay](https://github.com/tomquist/hame-relay) with your Marstek account credentials — on startup it prints each device's MAC and encrypted ID:
 
    ```text
    Device 1:
-     Name: ...
      Device ID: 009b08a571ee
      Remote ID: defa85f58f79ab2d2b2818f0a8cd3ee3   <-- the encrypted ID
-     MAC: 009b08a571ee
      Type: HMJ-2
-     ...
    ```
 
-   Hame Relay computes the ID from your account's device list, so this works even if the battery never publishes on a `/device/` topic (e.g. because you gave up waiting in Step 5) and even before it has ever connected to Marsrelay. You can uninstall Hame Relay again afterwards — Marsrelay setups don't need it running.
+   This works even if the battery never publishes (or has never connected to Marsrelay); uninstall Hame Relay again afterwards.
 
----
+## Optional: Shelly UDP Emulator
 
-## Troubleshooting
-
-### The battery doesn't react to commands (e.g. `cd=1`)
-
-Marsrelay's log shows `Received control message: ...` but the battery never answers. The command is reaching Marsrelay, but it doesn't match the topic the battery actually listens on. There are two common causes — compare the `.../device/<deviceId>/...` topic the battery publishes on (see [Step 5](#step-5-find-your-device-information)) with the topic your commands arrive on:
-
-**Cause 1: Wrong topic prefix (`hame_energy` vs. `marstek_energy`).** Batteries use one of two cloud topic prefixes depending on their firmware generation: older firmware talks to the 2024-generation cloud broker using `hame_energy/...`, newer firmware to the 2025 generation using `marstek_energy/...`. The current example configuration forwards commands for both prefixes, but configs created from an older version of the example only subscribe `marstek_energy/+/App/+/ctrl`. If your battery's `/device/` topics appear under `hame_energy/...`, make sure that prefix is subscribed as well in the `mqtt.on_connect` lambda:
-
-```yaml
-mqtt:
-  # ...
-  on_connect:
-    - lambda: |-
-        id(mqtt_client).subscribe("hame_energy/+/App/+/ctrl", [=](const std::string &topic, const std::string &payload) {
-          ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
-          id(local_broker).publish_message(topic, payload);
-        });
-        // keep the existing marstek_energy subscription from the example config here as well
-```
-
-The outgoing direction needs no change: the `mosquitto_broker` `on_message` forwarding matches any topic containing `/device/`, regardless of prefix.
-
-**Cause 2: The device ID in the topic doesn't match what hm2mqtt publishes to.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142), so this often shows up right after a firmware update. The fix depends on the device family:
-
-- **Venus/Jupiter and other non-B2500 devices:** find the battery's encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
-- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** keep the **Bluetooth MAC** as the `deviceId` in hm2mqtt and add an `id_mappings` entry mapping the battery's topic ID to that MAC (see [Device IDs](#device-ids-mac-address-vs-encrypted-id); requires a current Marsrelay build). If you pasted the battery's topic ID into hm2mqtt instead, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log).
-
-### No `.../device/...` topic ever appears in MQTT Explorer
-
-Work through this checklist:
-
-1. **Are you looking at the right topics?** Topics under `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data from your battery. Only `.../device/...` topics come from the battery — and they may appear under the `hame_energy/...` prefix instead of `marstek_energy/...` depending on firmware, so watch both.
-2. **Wait long enough.** The battery can take up to 20 minutes to publish. Keep MQTT Explorer connected the whole time.
-3. **Is the battery really connected to the Marsrelay access point?** The Marstek app sometimes reports a successful WiFi change even though the battery didn't actually connect. Check the Marsrelay logs (web interface or USB): when the battery is connected, you'll see its HTTP requests, e.g. `HTTP GET /app/neng/getDateInfoeu.php`. If those requests appear but no MQTT `/device/` topic does, the battery is connected and the problem is on the MQTT side (see next points).
-4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`, `mqtt_username` and `mqtt_password` in the substitutions, and check the ESPHome logs for MQTT connection errors.
-5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make sure the `psram` settings match your board.
-
-If you only need the device ID while you keep debugging, you don't have to wait for the topic: get it from Hame Relay's startup logs instead (see [Finding the encrypted ID](#finding-the-encrypted-id)).
-
-### The log repeats `getDateInfoeu.php` requests and UDP proxy messages — is something wrong?
-
-No — that's what healthy operation looks like. `HTTP GET /app/neng/getDateInfoeu.php` is the battery checking in with the (emulated) cloud, and the `udp_proxy` lines are power meter packets being bridged between the networks. Both repeat at fixed intervals for as long as the battery is connected.
-
-Two related things that are easy to misread:
-
-- The messages on `<mqtt_topic_prefix>/request` (e.g. `marsrelay/request`) on your home broker, like `{"source_ip":...,"url":"/app/neng/getDateInfoeu.php",...}`, are **diagnostic logs** of the battery's HTTP requests — they are not battery data and you don't need to do anything with them.
-- The battery does **not** push its telemetry (SoC, solar power, ...) on its own. That data only appears under the `.../device/...` topics when something requests it — which is exactly what [hm2mqtt](https://github.com/tomquist/hm2mqtt) does (e.g. by sending `cd=1`). If you only run Marsrelay without hm2mqtt, seeing nothing but `request` messages is expected.
-
-### Communication stops after a few hours, or the log shows broker crashes
-
-If the ESP32 log shows `***ERROR*** A stack overflow in task mosq_broker` or `Unable to accept new connection, system socket count has been exceeded`, first make sure you're on the latest `main` — earlier versions of the embedded broker had crash bugs that have since been fixed. Beyond that:
-
-- Some users report better long-term stability with `CONFIG_LWIP_MAX_SOCKETS: "32"` and `CONFIG_LWIP_SOCKET_OFFSET: "16"` in the `sdkconfig_options` (instead of the defaults from the example config).
-- A power cycle of the ESP32 restores communication as a stopgap.
-- The log line `TLS client: certificate verification relaxed (CN check disabled, ...)` is expected with `tls_skip_verification: true` and is not an error.
-- If crashes persist, double-check the `psram` settings match your board, and consider trying a standard ESP32-S3 devkit board.
-
-Long-running dropouts where MQTT and UDP stop together while WiFi stays up are still being investigated in [issue #10](https://github.com/tomquist/marsrelay/issues/10) — if you're affected, the debugging steps and current findings are collected there.
-
-### The battery can't reach a power meter on my home network (e.g. EcoTracker)
-
-The Marsrelay access point is a separate network, so devices on your home LAN are not directly reachable from the battery. The `udp_proxy` component bridges exactly one thing: **UDP broadcasts** used by the supported meter protocols (Shelly, CT00x). Meters that are polled over **TCP** — such as the everHome EcoTracker — cannot be bridged this way ([issue #16](https://github.com/tomquist/marsrelay/issues/16)).
-
-Workaround: bring the meter reading into ESPHome as a sensor (for example imported from Home Assistant) and serve it to the battery with the [Shelly UDP emulator](#optional-shelly-udp-emulator-issue-6) directly on the ESP32.
-
-### hm2mqtt shows all entities as unavailable (or values frozen at old state)
-
-hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC, with an `id_mappings` entry mapping the battery's topic ID to that MAC; for all other devices the configured ID must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
-
-### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
-
-Not with this codebase — it's an ESPHome project. But the concept ports: you'd need a WiFi hotspot, a DNS server that resolves every query to the Pi itself, an HTTP server implementing the Marstek cloud endpoints (see `components/marstack/` for the protocol), and a TLS-enabled MQTT broker on port 8883 that bridges to your main broker (see `components/mosquitto_broker/` for the topic handling). The [How It Works](#how-it-works) section describes how the pieces fit together.
-
----
-
-## Optional: Shelly UDP Emulator (Issue #6)
-
-Marsrelay can emulate a Shelly Gen2 energy meter (UDP JSON-RPC) using ESPHome sensor values.
-This is based on the Shelly emulation implemented in <https://github.com/tomquist/AstraMeter> (formerly b2500-meter).
-
-Example:
+Marsrelay can emulate a Shelly Gen2 energy meter (UDP JSON-RPC) directly on the ESP32, fed by ESPHome sensor values — based on the Shelly emulation in [AstraMeter](https://github.com/tomquist/AstraMeter) (formerly b2500-meter). Supports `EM.GetStatus` and `EM1.GetStatus`.
 
 ```yaml
 sensor:
@@ -467,49 +146,18 @@ shelly_emulator:
     - grid_power_w
 ```
 
-Supported methods:
-- `EM.GetStatus` (returns `a_act_power`, `b_act_power`, `c_act_power`, `total_act_power`)
-- `EM1.GetStatus` (returns `act_power`)
+## Troubleshooting
 
-## Technical Details
+See [docs/troubleshooting.md](docs/troubleshooting.md) for:
 
-This repository contains ESPHome external components for building Marsrelay:
-
-### Components
-
-- **`mosquitto_broker`**: An embedded MQTT broker that forwards messages from Marstek devices to your main MQTT broker
-- **`marstack`**: A web server component that implements Marstek's API endpoints
-- **`capture_dns`**: DNS redirection component that intercepts DNS queries and redirects them to the device
-- **`udp_proxy`**: UDP proxy component that bridges UDP broadcasts between the AP network (where Marstek devices connect) and the STA network (your home network). This enables zero feed-in control by forwarding UDP discovery/control packets between networks. Supports multiple ports.
-- **`shelly_emulator`**: Shelly UDP (Gen2) emulator for `EM.GetStatus`/`EM1.GetStatus` based on ESPHome sensor(s). Can be used to provide Shelly-compatible power readings directly from the ESP.
-- **`wifi`**: Patched WiFi component to support simultaneous access point while station mode is enabled
-
-### Requirements
-
-- ESP32-S3 device (ESP-IDF framework)
-- ESPHome
-- MQTT broker on your network
+- [The battery doesn't react to commands (e.g. cd=1)](docs/troubleshooting.md#the-battery-doesnt-react-to-commands-eg-cd1)
+- [No /device/ topic ever appears](docs/troubleshooting.md#no-device-topic-ever-appears)
+- [Repeating getDateInfoeu.php requests and UDP proxy log lines](docs/troubleshooting.md#repeating-getdateinfoeuphp-requests-and-udp-proxy-log-lines) (spoiler: that's normal)
+- [Communication stops after a few hours / broker crashes](docs/troubleshooting.md#communication-stops-after-a-few-hours-or-the-log-shows-broker-crashes)
+- [The battery can't reach a power meter on my home network](docs/troubleshooting.md#the-battery-cant-reach-a-power-meter-on-my-home-network-eg-ecotracker)
+- [hm2mqtt shows all entities as unavailable](docs/troubleshooting.md#hm2mqtt-shows-all-entities-as-unavailable)
+- [Can I run Marsrelay on a Raspberry Pi?](docs/troubleshooting.md#can-i-run-marsrelay-on-a-raspberry-pi-instead-of-an-esp32)
 
 ## License
 
-MIT License
-
-Copyright (c) 2024
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ If nothing has appeared after 20 minutes, you don't have to keep waiting: you ca
 
 Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://github.com/tomquist/hm2mqtt) configuration file. Your Marstek Energy Storage system is now integrated with your home automation!
 
-> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, what to put into hm2mqtt depends on your device family — B2500/Saturn devices always get the Bluetooth MAC, other devices get the encrypted ID (or an ID mapping). Read [Device IDs](#device-ids-mac-address-vs-encrypted-id) before continuing.
+> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, what to put into hm2mqtt depends on your device family — B2500/Saturn devices always get the Bluetooth MAC (usually combined with an `id_mappings` entry in Marsrelay), other devices get the encrypted ID directly (or the MAC plus a mapping). Read [Device IDs](#device-ids-mac-address-vs-encrypted-id) before continuing.
 
 ---
 
@@ -293,11 +293,32 @@ Marsrelay forwards the battery's topics as-is, so the ID you found in [Step 5](#
 
 ### B2500 / Saturn (device types starting with HMA, HMB, HMF, HMK, HMJ)
 
-Configure the **Bluetooth MAC** as the `deviceId` in hm2mqtt — even though the topics show an encrypted ID. hm2mqtt knows the B2500 encryption scheme and derives the encrypted topic ID from the MAC by itself, so its topics match the battery automatically. No `id_mappings` in Marsrelay are needed.
+Two rules apply to B2500 devices:
 
-Do **not** paste the encrypted ID from the `/device/` topic into hm2mqtt: hm2mqtt would encrypt it a *second* time and publish commands to a nonsense topic that the battery never sees. You can recognize this mistake in the Marsrelay log by extra-long IDs (~96 characters instead of 32) in the `.../App/.../ctrl` topics.
+1. **hm2mqtt always gets the Bluetooth MAC as `deviceId` — never the ID from the topic.** hm2mqtt builds its B2500 topics from the configured value itself: it publishes and listens under the plain MAC on `hame_energy/...` topics and under an encrypted variant it derives from the MAC on `marstek_energy/...` topics. Configuring anything other than the MAC breaks this derivation — you can recognize that mistake in the Marsrelay log by extra-long IDs (~96 characters) in the `.../App/.../ctrl` topics. Option A below is therefore **not** available for B2500.
+2. **You will usually also need an `id_mappings` entry in Marsrelay**, because on cloud MQTT — which is what the battery speaks to Marsrelay — a B2500 identifies itself with its cloud identity, not with the plain MAC.
 
-> **B2500 configured for local MQTT:** If you configured your B2500 to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC regardless of firmware version. Same conclusion: use the MAC in hm2mqtt, and no ID handling is needed.
+What to put into the mapping depends on the prefix of the battery's `/device/` topic from [Step 5](#step-5-find-your-device-information):
+
+- **Battery publishes under `hame_energy/...` (older firmware):** the ID in the topic is the battery's 24-character cloud device ID. Map it to the MAC:
+
+  ```yaml
+  id_mappings:
+    - device: "<24-char-id-from-the-device-topic>"
+      external: "<bluetooth-mac>"
+  ```
+
+  Also make sure commands are forwarded for the `hame_energy` prefix — the example config only forwards `marstek_energy` (see [Troubleshooting](#the-battery-doesnt-react-to-commands-eg-cd1), Cause 1).
+
+- **Battery publishes under `marstek_energy/...` (newer firmware):** compare the ID in the battery's `/device/` topic with the ID hm2mqtt publishes commands under on the same prefix — the `marstek_energy/<deviceType>/App/<id>/ctrl` topics you can see in MQTT Explorer or in the Marsrelay log (that ID is hm2mqtt's encrypted variant of the MAC, 32 hex characters). If the two IDs are **identical**, you're done — no mapping needed. If they **differ** (the battery uses an ID that can't be derived from the MAC alone), map the battery's ID to hm2mqtt's:
+
+  ```yaml
+  id_mappings:
+    - device: "<id-from-the-battery's-device-topic>"
+      external: "<id-from-hm2mqtt's-App-topic>"
+  ```
+
+> **B2500 configured for local MQTT:** If you configured your B2500 to talk to your local MQTT broker directly (e.g. via [hmjs](https://tomquist.github.io/hmjs/)), it doesn't use its cloud identity — it publishes under the plain MAC on `hame_energy/...` topics, which matches hm2mqtt directly. Use the MAC in hm2mqtt; no mapping is needed.
 
 ### Venus, Jupiter and all other device types (VNS…, JPLS…, HMG…, HMM…, …)
 
@@ -333,8 +354,6 @@ For each pair, `device` is the encrypted ID that appears in the topic on the loc
 With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt configuration. When you have multiple batteries, make sure each mapping pairs the encrypted ID and the MAC of the **same physical battery** (see [Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one battery if you're unsure which ID belongs to which).
 
 ### Finding the encrypted ID
-
-(You only need this for Venus/Jupiter and the other non-B2500 device types — for B2500/Saturn devices the Bluetooth MAC is all you need, see above.)
 
 Two ways to find out which encrypted ID belongs to which battery:
 
@@ -380,7 +399,7 @@ The outgoing direction needs no change: the `mosquitto_broker` `on_message` forw
 **Cause 2: The device ID in the topic doesn't match what hm2mqtt publishes to.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142), so this often shows up right after a firmware update. The fix depends on the device family:
 
 - **Venus/Jupiter and other non-B2500 devices:** find the battery's encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
-- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** configure the **Bluetooth MAC** as the `deviceId` — hm2mqtt derives the encrypted ID itself. If you pasted the encrypted ID from the topic into hm2mqtt, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** keep the **Bluetooth MAC** as the `deviceId` in hm2mqtt and add an `id_mappings` entry that connects the battery's topic ID to the ID hm2mqtt publishes under — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for exactly which value goes where. If you pasted the battery's topic ID into hm2mqtt instead, that's the problem: commands end up on a double-encrypted topic (visible as ~96-character IDs in the Marsrelay log).
 
 ### No `.../device/...` topic ever appears in MQTT Explorer
 
@@ -422,7 +441,7 @@ Workaround: bring the meter reading into ESPHome as a sensor (for example import
 
 ### hm2mqtt shows all entities as unavailable (or values frozen at old state)
 
-hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC (hm2mqtt derives the encrypted topic ID from it), for all other devices it must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the `deviceId` configured in hm2mqtt against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices the configured ID must be the Bluetooth MAC and the battery's topic ID usually needs an `id_mappings` entry on top; for all other devices the configured ID must match the topic ID exactly (or be connected via an `id_mappings` entry). See [Device IDs](#device-ids-mac-address-vs-encrypted-id).
 
 ### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Marstek batteries talk to two cloud services: an HTTP API (date/time sync and si
 2. **Redirects Internet Requests** (`capture_dns` component): When the battery looks up any Marstek cloud hostname via DNS, Marsrelay answers with its own IP address, so all cloud traffic ends up at the ESP32
 3. **Acts Like Marstek's HTTP Server** (`marstack` component): A web server responds to the Marstek cloud HTTP endpoints the battery calls (for example `GET /app/neng/getDateInfoeu.php`, which the battery uses to sync its clock), so the battery believes it is talking to the real cloud
 4. **Acts Like Marstek's MQTT Broker** (`mosquitto_broker` component): An embedded TLS MQTT broker (port 8883) accepts the battery's cloud MQTT connection and bridges it to your home network:
-   - Messages the battery publishes on `marstek_energy/<deviceType>/device/<deviceId>/...` are forwarded to your home MQTT broker
+   - Messages the battery publishes on `marstek_energy/<deviceType>/device/<deviceId>/...` (or `hame_energy/...` on older firmware) are forwarded to your home MQTT broker
    - Control messages published on your home broker under `marstek_energy/<deviceType>/App/<deviceId>/ctrl` (for example by [hm2mqtt](https://github.com/tomquist/hm2mqtt)) are delivered back to the battery
 5. **Bridges Power Meter Traffic** (`udp_proxy` component): UDP broadcasts used for power meter discovery and zero feed-in control are relayed between the battery's network and your home network
 
@@ -267,6 +267,8 @@ Edit the `substitutions` section at the top of the configuration file:
 2. Wait for a message to appear on the topic: `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. The battery publishes on its own schedule — **this can take up to 20 minutes**, so keep MQTT Explorer connected and be patient
 3. Note down the **`deviceType`** and **`deviceId`** from the topic
 
+> **Check both topic prefixes.** Depending on its firmware generation, the battery uses either `marstek_energy/...` or the older `hame_energy/...` prefix for its cloud topics, so the `/device/` topic may appear under either one. If your battery uses `hame_energy`, one config adjustment is needed so commands reach it — see [Troubleshooting](#the-battery-doesnt-react-to-commands-eg-cd1).
+
 > **Only topics containing `/device/` come from your battery.** You will likely also see topics like `marstek_energy/<deviceType>/App/<id>/ctrl` — these are control messages *sent by* hm2mqtt (or the app), not by your battery. They tell you nothing about your battery's device ID, so ignore them in this step.
 
 Depending on the battery's firmware version, the `deviceId` in the topic is either the battery's Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`) or a much longer encrypted ID. Both are normal — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for what this means for your hm2mqtt configuration.
@@ -343,23 +345,65 @@ Two ways to find out which encrypted ID belongs to which battery:
 
 ## Troubleshooting
 
-### The battery stopped reacting to commands (e.g. `cd=1`) after a firmware update
+### The battery doesn't react to commands (e.g. `cd=1`)
 
-Newer firmware switches the battery from using its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142). Marsrelay still forwards everything, but hm2mqtt keeps publishing commands to the old MAC-based topic that the battery no longer listens on.
+Marsrelay's log shows `Received control message: ...` but the battery never answers. The command is reaching Marsrelay, but it doesn't match the topic the battery actually listens on. There are two common causes — compare the `.../device/<deviceId>/...` topic the battery publishes on (see [Step 5](#step-5-find-your-device-information)) with the topic your commands arrive on:
 
-**Fix:** find the battery's new encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
+**Cause 1: Wrong topic prefix (`hame_energy` vs. `marstek_energy`).** Batteries use one of two cloud topic prefixes depending on their firmware generation: older firmware talks to the 2024-generation cloud broker using `hame_energy/...`, newer firmware to the 2025 generation using `marstek_energy/...`. The example configuration only forwards commands for `marstek_energy/+/App/+/ctrl`. If your battery's `/device/` topics appear under `hame_energy/...`, subscribe to that prefix as well (or instead) in the `mqtt.on_connect` lambda:
+
+```yaml
+mqtt:
+  # ...
+  on_connect:
+    - lambda: |-
+        id(mqtt_client).subscribe("hame_energy/+/App/+/ctrl", [=](const std::string &topic, const std::string &payload) {
+          ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
+          id(local_broker).publish_message(topic, payload);
+        });
+        // keep the existing marstek_energy subscription from the example config here as well
+```
+
+The outgoing direction needs no change: the `mosquitto_broker` `on_message` forwarding matches any topic containing `/device/`, regardless of prefix.
+
+**Cause 2: The device ID changed to an encrypted ID after a firmware update.** Newer firmware switches the battery from its plain MAC address to an [encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics (e.g. Jupiter C+ with firmware v142). hm2mqtt then keeps publishing commands to the old MAC-based topic that the battery no longer listens on. **Fix:** find the battery's new encrypted ID (see [Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your setup stays fully offline either way.
 
 ### No `.../device/...` topic ever appears in MQTT Explorer
 
 Work through this checklist:
 
-1. **Are you looking at the right topics?** Topics under `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data from your battery. Only `.../device/...` topics come from the battery.
+1. **Are you looking at the right topics?** Topics under `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data from your battery. Only `.../device/...` topics come from the battery — and they may appear under the `hame_energy/...` prefix instead of `marstek_energy/...` depending on firmware, so watch both.
 2. **Wait long enough.** The battery can take up to 20 minutes to publish. Keep MQTT Explorer connected the whole time.
 3. **Is the battery really connected to the Marsrelay access point?** The Marstek app sometimes reports a successful WiFi change even though the battery didn't actually connect. Check the Marsrelay logs (web interface or USB): when the battery is connected, you'll see its HTTP requests, e.g. `HTTP GET /app/neng/getDateInfoeu.php`. If those requests appear but no MQTT `/device/` topic does, the battery is connected and the problem is on the MQTT side (see next points).
 4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`, `mqtt_username` and `mqtt_password` in the substitutions, and check the ESPHome logs for MQTT connection errors.
 5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make sure the `psram` settings match your board.
 
 If you only need the device ID while you keep debugging, you don't have to wait for the topic: get it from Hame Relay's startup logs instead (see [Finding the encrypted ID](#finding-the-encrypted-id)).
+
+### The log repeats `getDateInfoeu.php` requests and UDP proxy messages — is something wrong?
+
+No — that's what healthy operation looks like. `HTTP GET /app/neng/getDateInfoeu.php` is the battery checking in with the (emulated) cloud, and the `udp_proxy` lines are power meter packets being bridged between the networks. Both repeat at fixed intervals for as long as the battery is connected.
+
+Two related things that are easy to misread:
+
+- The messages on `<mqtt_topic_prefix>/request` (e.g. `marsrelay/request`) on your home broker, like `{"source_ip":...,"url":"/app/neng/getDateInfoeu.php",...}`, are **diagnostic logs** of the battery's HTTP requests — they are not battery data and you don't need to do anything with them.
+- The battery does **not** push its telemetry (SoC, solar power, ...) on its own. That data only appears under the `.../device/...` topics when something requests it — which is exactly what [hm2mqtt](https://github.com/tomquist/hm2mqtt) does (e.g. by sending `cd=1`). If you only run Marsrelay without hm2mqtt, seeing nothing but `request` messages is expected.
+
+### Communication stops after a few hours, or the log shows broker crashes
+
+If the ESP32 log shows `***ERROR*** A stack overflow in task mosq_broker` or `Unable to accept new connection, system socket count has been exceeded`, first make sure you're on the latest `main` — earlier versions of the embedded broker had crash bugs that have since been fixed. Beyond that:
+
+- Some users report better long-term stability with `CONFIG_LWIP_MAX_SOCKETS: "32"` and `CONFIG_LWIP_SOCKET_OFFSET: "16"` in the `sdkconfig_options` (instead of the defaults from the example config).
+- A power cycle of the ESP32 restores communication as a stopgap.
+- The log line `TLS client: certificate verification relaxed (CN check disabled, ...)` is expected with `tls_skip_verification: true` and is not an error.
+- If crashes persist, double-check the `psram` settings match your board, and consider trying a standard ESP32-S3 devkit board.
+
+Long-running dropouts where MQTT and UDP stop together while WiFi stays up are still being investigated in [issue #10](https://github.com/tomquist/marsrelay/issues/10) — if you're affected, the debugging steps and current findings are collected there.
+
+### The battery can't reach a power meter on my home network (e.g. EcoTracker)
+
+The Marsrelay access point is a separate network, so devices on your home LAN are not directly reachable from the battery. The `udp_proxy` component bridges exactly one thing: **UDP broadcasts** used by the supported meter protocols (Shelly, CT00x). Meters that are polled over **TCP** — such as the everHome EcoTracker — cannot be bridged this way ([issue #16](https://github.com/tomquist/marsrelay/issues/16)).
+
+Workaround: bring the meter reading into ESPHome as a sensor (for example imported from Home Assistant) and serve it to the battery with the [Shelly UDP emulator](#optional-shelly-udp-emulator-issue-6) directly on the ESP32.
 
 ### hm2mqtt shows all entities as unavailable (or values frozen at old state)
 

--- a/README.md
+++ b/README.md
@@ -16,19 +16,63 @@ Marsrelay replaces the Marstek cloud service with a small device that runs local
 
 ## How It Works
 
-When you set up Marsrelay:
+Marstek batteries talk to two cloud services: an HTTP API (date/time sync and similar requests) and an MQTT broker (telemetry and control). Marsrelay emulates both on a single ESP32-S3, so the battery behaves exactly as if it were online:
 
-1. **Creates a WiFi Network**: Marsrelay opens its own WiFi access point that your Marstek Energy Storage device connects to (just like connecting to WiFi)
-2. **Redirects Internet Requests**: When your Marstek device tries to reach the internet, Marsrelay intercepts those requests and redirects them to itself instead
-3. **Acts Like Marstek's Server**: Marsrelay includes a web server that responds to your Marstek device the same way Marstek's cloud service would, so your device thinks it's connected normally
-4. **Forwards Messages**: Marsrelay includes an MQTT broker (a messaging system) that:
-   - Receives messages from your Marstek device
-   - Forwards them to your home automation system's MQTT broker
-   - This allows projects like hm2mqtt to monitor and control your Marstek system
+1. **Creates a WiFi Network** (`wifi` component): Marsrelay opens its own WiFi access point that your Marstek device connects to, while at the same time staying connected to your home WiFi as a regular client
+2. **Redirects Internet Requests** (`capture_dns` component): When the battery looks up any Marstek cloud hostname via DNS, Marsrelay answers with its own IP address, so all cloud traffic ends up at the ESP32
+3. **Acts Like Marstek's HTTP Server** (`marstack` component): A web server responds to the Marstek cloud HTTP endpoints the battery calls (for example `GET /app/neng/getDateInfoeu.php`, which the battery uses to sync its clock), so the battery believes it is talking to the real cloud
+4. **Acts Like Marstek's MQTT Broker** (`mosquitto_broker` component): An embedded TLS MQTT broker (port 8883) accepts the battery's cloud MQTT connection and bridges it to your home network:
+   - Messages the battery publishes on `marstek_energy/<deviceType>/device/<deviceId>/...` are forwarded to your home MQTT broker
+   - Control messages published on your home broker under `marstek_energy/<deviceType>/App/<deviceId>/ctrl` (for example by [hm2mqtt](https://github.com/tomquist/hm2mqtt)) are delivered back to the battery
+5. **Bridges Power Meter Traffic** (`udp_proxy` component): UDP broadcasts used for power meter discovery and zero feed-in control are relayed between the battery's network and your home network
+
+```mermaid
+flowchart LR
+    subgraph AP["Marsrelay WiFi AP"]
+        Battery[Marstek battery]
+    end
+    subgraph ESP["Marsrelay (ESP32-S3)"]
+        DNS[capture_dns<br/>DNS redirection]
+        HTTP[marstack<br/>cloud HTTP emulation]
+        Broker[mosquitto_broker<br/>cloud MQTT emulation]
+        UDP[udp_proxy]
+    end
+    subgraph Home["Home network"]
+        HomeBroker[Your MQTT broker]
+        HM2MQTT[hm2mqtt]
+        HA[Home Assistant]
+        Meter[Smart meter / b2500-meter]
+    end
+    Battery -->|DNS lookups| DNS
+    Battery -->|HTTP| HTTP
+    Battery <-->|MQTT over TLS| Broker
+    Battery <-.->|UDP broadcasts| UDP
+    UDP <-.-> Meter
+    Broker <-->|forwards both directions| HomeBroker
+    HomeBroker <--> HM2MQTT
+    HM2MQTT <--> HA
+```
 
 ## The Result
 
 Your Marstek Energy Storage system operates completely offline, thinking it's connected to Marstek's cloud, while all its data and controls are available to your home automation system through MQTT.
+
+Note that the official Marstek app can no longer reach the battery through the cloud in this setup — that's the point of going offline. You can still use the app via Bluetooth when you are near the battery.
+
+## Marsrelay, hm2mqtt and Hame Relay
+
+Three related projects are often mentioned together. They solve different problems:
+
+| Project | Role |
+|---------|------|
+| **Marsrelay** (this project) | Replaces the Marstek **cloud** locally. Batteries connect to it over WiFi; it forwards their raw MQTT messages to your home broker. Runs on an ESP32-S3. |
+| **[hm2mqtt](https://github.com/tomquist/hm2mqtt)** | Parses the raw battery MQTT messages and integrates them with Home Assistant (auto-discovery, sensors, controls). Runs as a Home Assistant add-on or Docker container. |
+| **[Hame Relay](https://github.com/tomquist/hame-relay)** | Bridges MQTT between the **real** Marstek cloud and your local broker, for setups where the battery stays cloud-connected. |
+
+In a Marsrelay setup:
+
+- **You still need hm2mqtt.** Marsrelay only moves raw MQTT messages; it doesn't parse them or create Home Assistant entities. hm2mqtt works the same whether the data arrives via Marsrelay or via Hame Relay.
+- **You don't need Hame Relay.** With Marsrelay the battery never talks to the real cloud, so there is nothing to bridge. The one exception: temporarily installing Hame Relay is a convenient way to look up a battery's encrypted device ID (see [Device IDs](#device-ids-mac-address-vs-encrypted-id) below) — you can uninstall it again afterwards.
 
 ---
 
@@ -220,45 +264,170 @@ Edit the `substitutions` section at the top of the configuration file:
 ### Step 5: Find Your Device Information
 
 1. Open MQTT Explorer (or another MQTT client) and connect to your MQTT broker
-2. Wait up to 20 minutes for a message to appear on the topic: `marstek_energy/<deviceType>/device/<deviceId>/ctrl`
+2. Wait for a message to appear on the topic: `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. The battery publishes on its own schedule — **this can take up to 20 minutes**, so keep MQTT Explorer connected and be patient
 3. Note down the **`deviceType`** and **`deviceId`** from the topic
+
+> **Only topics containing `/device/` come from your battery.** You will likely also see topics like `marstek_energy/<deviceType>/App/<id>/ctrl` — these are control messages *sent by* hm2mqtt (or the app), not by your battery. They tell you nothing about your battery's device ID, so ignore them in this step.
+
+Depending on the battery's firmware version, the `deviceId` in the topic is either the battery's Bluetooth MAC address (12 hex characters, e.g. `009b08a571ee`) or a much longer encrypted ID. Both are normal — see [Device IDs](#device-ids-mac-address-vs-encrypted-id) for what this means for your hm2mqtt configuration.
+
+If no `/device/` topic ever shows up, see [Troubleshooting](#troubleshooting).
 
 ### Step 6: Configure hm2mqtt
 
 Copy the `deviceType` and `deviceId` you found into your [hm2mqtt](https://github.com/tomquist/hm2mqtt) configuration file. Your Marstek Energy Storage system is now integrated with your home automation!
 
+> If the `deviceId` from Step 5 is a long encrypted ID rather than a MAC address, you can either use it directly in hm2mqtt or keep using the Bluetooth MAC and let Marsrelay translate — see [Device IDs](#device-ids-mac-address-vs-encrypted-id).
+
 ---
 
-## Optional: Battery ID Mapping (Issue #19)
+## Device IDs: MAC Address vs. Encrypted ID
 
-Marstek batteries use a long ID in their cloud MQTT topics, while
-[hm2mqtt](https://github.com/tomquist/hm2mqtt) and
-[Hame Relay](https://github.com/tomquist/hame-relay) expect the battery's
-Bluetooth MAC address as the device ID. To bridge the two, marsrelay can
-rewrite the ID segment of every topic it forwards.
+Every Marstek battery has a Bluetooth MAC address (12 hex characters, e.g.
+`009b08a571ee`). This is what [hm2mqtt](https://github.com/tomquist/hm2mqtt)
+normally uses as the `deviceId`, and it's shown in the Marstek app and
+Bluetooth tools.
 
-Add an `id_mappings` list to the `mosquitto_broker:` block:
+However, on newer firmware the battery does **not** use its MAC in the cloud
+MQTT topics. Instead it uses a long **encrypted ID** derived from the MAC —
+for example `defa85f58f79ab2d2b2818f0a8cd3ee3` or an even longer string.
+Which form your battery uses depends on the model and firmware version (for
+example HMJ-2 switched with firmware v108, Jupiter/JPLS with v136 — Jupiter C+
+users first noticed this on firmware v142; see the
+[Hame Relay device matrix](https://github.com/tomquist/hame-relay/blob/main/docs/device-matrix.md)
+for details). A firmware update can silently switch a battery from MAC to
+encrypted ID — if your battery suddenly stops reacting to commands after an
+update, this is almost certainly why (see [Troubleshooting](#troubleshooting)).
+
+Marsrelay forwards the battery's topics as-is, so the ID you found in
+[Step 5](#step-5-find-your-device-information) is whatever the battery uses.
+If that ID is the plain MAC address, you're done — configure it in hm2mqtt and
+skip the rest of this section. If it's an encrypted ID, pick one of the two
+options below.
+
+> **Batteries configured for local MQTT:** If you configured a B2500 battery
+> to talk to your local MQTT broker directly (e.g. via
+> [hmjs](https://tomquist.github.io/hmjs/)), it publishes under its plain MAC
+> regardless of firmware version. No encrypted ID handling is needed for such
+> a battery — leave everything as is.
+
+### Option A: Use the encrypted ID directly in hm2mqtt
+
+The simplest approach: configure the encrypted ID from Step 5 as the
+`deviceId` in hm2mqtt, e.g.
+
+```yaml
+devices:
+  - deviceType: "JPLS-8H"
+    deviceId: "defa85f58f79ab2d2b2818f0a8cd3ee3"
+```
+
+or, for a Docker setup, `DEVICE_0=JPLS-8H:defa85f58f79ab2d2b2818f0a8cd3ee3`.
+
+### Option B: Let Marsrelay translate between encrypted ID and MAC
+
+Alternatively, keep the familiar Bluetooth MAC in your hm2mqtt configuration
+and have Marsrelay rewrite the ID segment of every topic it forwards. Add an
+`id_mappings` list to the `mosquitto_broker:` block:
 
 ```yaml
 mosquitto_broker:
   id: local_broker
   # ...existing options...
   id_mappings:
-    - device: "<long-id-from-cloud-mqtt-topic>"
+    - device: "<encrypted-id-from-the-device-topic>"
       external: "<bluetooth-mac-address>"
 ```
 
-For each pair, `device` is the long ID that appears in the topic on the local
-mosquitto broker (the one the battery uses for its cloud MQTT topics), and
-`external` is the Bluetooth MAC address that hm2mqtt / Hame Relay use as the
-device ID. Translation is applied in both directions automatically: control
-messages from hm2mqtt on `.../App/<external>/...` are rewritten to
+For each pair, `device` is the encrypted ID that appears in the topic on the
+local mosquitto broker (the one the battery uses for its cloud MQTT topics),
+and `external` is the Bluetooth MAC address that hm2mqtt uses as the device
+ID. Translation is applied in both directions automatically: control messages
+from hm2mqtt on `.../App/<external>/...` are rewritten to
 `.../App/<device>/...` before being delivered to the battery, and status
 messages from the battery on `.../device/<device>/...` are rewritten to
 `.../device/<external>/...` before being forwarded out.
 
-Use the `external` ID (the Bluetooth MAC) in your hm2mqtt / Hame Relay
-configuration.
+With this option, use the `external` ID (the Bluetooth MAC) in your hm2mqtt
+configuration. When you have multiple batteries, make sure each mapping pairs
+the encrypted ID and the MAC of the **same physical battery** (see
+[Finding the encrypted ID](#finding-the-encrypted-id) — power off all but one
+battery if you're unsure which ID belongs to which).
+
+### Finding the encrypted ID
+
+Two ways to find out which encrypted ID belongs to which battery:
+
+1. **MQTT Explorer** (no extra software): follow
+   [Step 5](#step-5-find-your-device-information) and wait for the battery to
+   publish on `marstek_energy/<deviceType>/device/<deviceId>/ctrl`. With
+   multiple batteries, power all but one off so you can attribute the ID
+   unambiguously. Remember: ignore `.../App/...` topics — only `/device/`
+   topics come from the battery.
+2. **Hame Relay startup logs**: temporarily install
+   [Hame Relay](https://github.com/tomquist/hame-relay) with your Marstek
+   account credentials. On startup it prints a block per device including the
+   Bluetooth MAC and the derived encrypted ID (the `Remote ID:` line). Since
+   it computes the ID from your account data, this also works before the
+   battery has ever connected to Marsrelay. You can uninstall Hame Relay again
+   afterwards — Marsrelay setups don't need it running.
+
+---
+
+## Troubleshooting
+
+### The battery stopped reacting to commands (e.g. `cd=1`) after a firmware update
+
+Newer firmware switches the battery from using its plain MAC address to an
+[encrypted ID](#device-ids-mac-address-vs-encrypted-id) in its MQTT topics
+(e.g. Jupiter C+ with firmware v142). Marsrelay still forwards everything, but
+hm2mqtt keeps publishing commands to the old MAC-based topic that the battery
+no longer listens on.
+
+**Fix:** find the battery's new encrypted ID (see
+[Finding the encrypted ID](#finding-the-encrypted-id)) and either configure it
+as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay. Your
+setup stays fully offline either way.
+
+### No `.../device/...` topic ever appears in MQTT Explorer
+
+Work through this checklist:
+
+1. **Are you looking at the right topics?** Topics under
+   `marstek_energy/<deviceType>/App/...` are commands *from* hm2mqtt, not data
+   from your battery. Only `.../device/...` topics come from the battery.
+2. **Wait long enough.** The battery can take up to 20 minutes to publish.
+   Keep MQTT Explorer connected the whole time.
+3. **Is the battery really connected to the Marsrelay access point?** The
+   Marstek app sometimes reports a successful WiFi change even though the
+   battery didn't actually connect. Check the Marsrelay logs (web interface or
+   USB): when the battery is connected, you'll see its HTTP requests, e.g.
+   `HTTP GET /app/neng/getDateInfoeu.php`. If those requests appear but no
+   MQTT `/device/` topic does, the battery is connected and the problem is on
+   the MQTT side (see next points).
+4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`,
+   `mqtt_username` and `mqtt_password` in the substitutions, and check the
+   ESPHome logs for MQTT connection errors.
+5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make
+   sure the `psram` settings match your board.
+
+### hm2mqtt shows all entities as unavailable (or values frozen at old state)
+
+hm2mqtt is waiting for data under a `deviceId` that doesn't match what the
+battery publishes. Compare the ID in the `.../device/<deviceId>/...` topic with
+the `deviceId` configured in hm2mqtt — they must match exactly (or be
+connected via an `id_mappings` entry). See
+[Device IDs](#device-ids-mac-address-vs-encrypted-id).
+
+### Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
+
+Not with this codebase — it's an ESPHome project. But the concept ports:
+you'd need a WiFi hotspot, a DNS server that resolves every query to the Pi
+itself, an HTTP server implementing the Marstek cloud endpoints (see
+`components/marstack/` for the protocol), and a TLS-enabled MQTT broker on
+port 8883 that bridges to your main broker (see `components/mosquitto_broker/`
+for the topic handling). The [How It Works](#how-it-works) section describes
+how the pieces fit together.
 
 ---
 

--- a/components/mosquitto_broker/__init__.py
+++ b/components/mosquitto_broker/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import automation
@@ -23,8 +25,35 @@ CONF_EXTERNAL = "external"
 # filter the local->external bridge relies on, which can in turn enable a
 # forwarding loop. Reject up front instead.
 RESERVED_ID_SEGMENTS = frozenset(
-    {"marstek_energy", "App", "device", "ctrl"}
+    {"hame_energy", "marstek_energy", "App", "device", "ctrl"}
 )
+
+_MAC_RE = re.compile(r"^[0-9a-fA-F]{12}$")
+# The key hm2mqtt (and the Marstek firmware) use to derive the encrypted
+# topic id of a B2500 from its Bluetooth MAC.
+_TOPIC_ID_ENCRYPTION_KEY = b"!@#$%^&*()_+{}[]"
+
+
+def _encrypted_external_id(external: str) -> str:
+    """Return the encrypted topic-id variant of a Bluetooth MAC.
+
+    hm2mqtt publishes and listens under AES-128-CBC(zero IV, PKCS7, hex) of the
+    configured MAC on `marstek_energy` topics for B2500 device types. Computing
+    the same variant here lets `id_mappings` accept the plain MAC as `external`
+    while still matching hm2mqtt's topics. Returns "" when `external` is not a
+    12-hex-digit MAC.
+    """
+    if not _MAC_RE.match(external):
+        return ""
+    from cryptography.hazmat.primitives import padding
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    padder = padding.PKCS7(128).padder()
+    data = padder.update(external.encode("utf-8")) + padder.finalize()
+    encryptor = Cipher(
+        algorithms.AES(_TOPIC_ID_ENCRYPTION_KEY), modes.CBC(b"\x00" * 16)
+    ).encryptor()
+    return (encryptor.update(data) + encryptor.finalize()).hex()
 
 
 def _validate_id_segment(value):
@@ -69,6 +98,21 @@ def _validate_id_mappings(value):
             )
         seen_devices.add(device)
         seen_externals.add(external)
+        encrypted = _encrypted_external_id(external)
+        if encrypted:
+            # The translator also matches/emits the encrypted variant of a MAC
+            # external, so it must be collision-free like the ids themselves.
+            # (Being equal to this mapping's own `device` is fine — that is the
+            # firmware whose topic id already equals hm2mqtt's derived id, and
+            # the mapping degrades to a no-op.)
+            if encrypted in seen_externals or (
+                encrypted in seen_devices and encrypted != device
+            ):
+                raise cv.Invalid(
+                    f"id_mappings[{index}]: encrypted form '{encrypted}' of external id "
+                    f"'{external}' collides with an id from another mapping"
+                )
+            seen_externals.add(encrypted)
     return value
 
 
@@ -133,7 +177,13 @@ async def to_code(config):
         await automation.build_automation(trigger, [(cg.std_string, "topic"), (cg.std_string, "payload")], conf)
 
     for mapping in config.get(CONF_ID_MAPPINGS, []):
-        cg.add(var.add_id_mapping(mapping[CONF_DEVICE], mapping[CONF_EXTERNAL]))
+        cg.add(
+            var.add_id_mapping(
+                mapping[CONF_DEVICE],
+                mapping[CONF_EXTERNAL],
+                _encrypted_external_id(mapping[CONF_EXTERNAL]),
+            )
+        )
 
 
 @automation.register_action(

--- a/components/mosquitto_broker/mosquitto_broker.cpp
+++ b/components/mosquitto_broker/mosquitto_broker.cpp
@@ -5,6 +5,7 @@
 #include "esp_tls.h"
 #include "mqtt_client.h"
 #include "esp_event.h"
+#include <cctype>
 #include <cstring>
 
 namespace esphome {
@@ -180,6 +181,41 @@ void MosquittoBroker::publish_message(const std::string &topic, const std::strin
   }
 }
 
+namespace {
+
+// Device families whose hm2mqtt integration derives an encrypted topic id from
+// the Bluetooth MAC on `marstek_energy` topics (mirrors hm2mqtt's list).
+bool is_b2500_type_segment(const std::string &segment) {
+  static const char *const B2500_BASE_TYPES[] = {"HMA", "HMF", "HMK", "HMJ"};
+  std::string base = segment.substr(0, segment.find('-'));
+  for (auto &c : base) {
+    c = static_cast<char>(::toupper(static_cast<unsigned char>(c)));
+  }
+  for (const char *base_type : B2500_BASE_TYPES) {
+    if (base == base_type) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// True when the external side of this topic uses the encrypted MAC variant:
+// hm2mqtt only does that on `marstek_energy/<b2500-type>/...` topics.
+bool topic_uses_encrypted_external(const std::string &topic) {
+  size_t first = topic.find('/');
+  if (first == std::string::npos) {
+    return false;
+  }
+  if (topic.compare(0, first, "marstek_energy") != 0) {
+    return false;
+  }
+  size_t second = topic.find('/', first + 1);
+  size_t type_end = (second == std::string::npos) ? topic.size() : second;
+  return is_b2500_type_segment(topic.substr(first + 1, type_end - first - 1));
+}
+
+}  // namespace
+
 std::string MosquittoBroker::translate_external_to_device_(const std::string &topic) const {
   if (this->id_mappings_.empty()) {
     return topic;
@@ -192,9 +228,16 @@ std::string MosquittoBroker::translate_external_to_device_(const std::string &to
     size_t end = (next == std::string::npos) ? topic.size() : next;
     bool replaced = false;
     for (const auto &mapping : this->id_mappings_) {
-      const std::string &external = mapping.second;
-      if (end - pos == external.size() && topic.compare(pos, external.size(), external) == 0) {
-        result.append(mapping.first);
+      // Accept both external forms regardless of prefix, so already-translated
+      // or manually configured encrypted ids keep working.
+      const bool matches_plain = end - pos == mapping.external.size() &&
+                                 topic.compare(pos, mapping.external.size(), mapping.external) == 0;
+      const bool matches_encrypted = !mapping.external_encrypted.empty() &&
+                                     end - pos == mapping.external_encrypted.size() &&
+                                     topic.compare(pos, mapping.external_encrypted.size(),
+                                                   mapping.external_encrypted) == 0;
+      if (matches_plain || matches_encrypted) {
+        result.append(mapping.device);
         replaced = true;
         break;
       }
@@ -215,6 +258,7 @@ std::string MosquittoBroker::translate_device_to_external_(const std::string &to
   if (this->id_mappings_.empty()) {
     return topic;
   }
+  const bool use_encrypted = topic_uses_encrypted_external(topic);
   std::string result;
   result.reserve(topic.size());
   size_t pos = 0;
@@ -223,9 +267,13 @@ std::string MosquittoBroker::translate_device_to_external_(const std::string &to
     size_t end = (next == std::string::npos) ? topic.size() : next;
     bool replaced = false;
     for (const auto &mapping : this->id_mappings_) {
-      const std::string &device = mapping.first;
+      const std::string &device = mapping.device;
       if (end - pos == device.size() && topic.compare(pos, device.size(), device) == 0) {
-        result.append(mapping.second);
+        if (use_encrypted && !mapping.external_encrypted.empty()) {
+          result.append(mapping.external_encrypted);
+        } else {
+          result.append(mapping.external);
+        }
         replaced = true;
         break;
       }

--- a/components/mosquitto_broker/mosquitto_broker.cpp
+++ b/components/mosquitto_broker/mosquitto_broker.cpp
@@ -184,7 +184,10 @@ void MosquittoBroker::publish_message(const std::string &topic, const std::strin
 namespace {
 
 // Device families whose hm2mqtt integration derives an encrypted topic id from
-// the Bluetooth MAC on `marstek_energy` topics (mirrors hm2mqtt's list).
+// the Bluetooth MAC on `marstek_energy` topics. This list must mirror
+// hm2mqtt's `encryptedDeviceTypes` exactly. HMB is deliberately absent even
+// though it belongs to the B2500 family: hm2mqtt uses the plain MAC for HMB,
+// and HMB firmware never uses the `marstek_energy` prefix anyway.
 bool is_b2500_type_segment(const std::string &segment) {
   static const char *const B2500_BASE_TYPES[] = {"HMA", "HMF", "HMK", "HMJ"};
   std::string base = segment.substr(0, segment.find('-'));

--- a/components/mosquitto_broker/mosquitto_broker.h
+++ b/components/mosquitto_broker/mosquitto_broker.h
@@ -31,6 +31,16 @@ class MosquittoMessageTrigger : public Trigger<std::string, std::string> {
 
 class MosquittoBroker : public Component {
  public:
+  struct IdMapping {
+    std::string device;
+    std::string external;
+    // hm2mqtt publishes/listens under an AES-derived variant of the Bluetooth
+    // MAC on `marstek_energy` topics for B2500 device types. This is that
+    // variant of `external`, precomputed at codegen time; empty when
+    // `external` is not a MAC address.
+    std::string external_encrypted;
+  };
+
   void setup() override;
   void loop() override;
   void dump_config() override;
@@ -44,8 +54,9 @@ class MosquittoBroker : public Component {
   void publish_message(const std::string &topic, const std::string &payload);
   void add_message_trigger(MosquittoMessageTrigger *trigger) { this->message_triggers_.push_back(trigger); }
   void set_publish_state(mqtt::MQTTClientState state) { this->publish_state_ = state; }
-  void add_id_mapping(const std::string &device, const std::string &external) {
-    this->id_mappings_.emplace_back(device, external);
+  void add_id_mapping(const std::string &device, const std::string &external,
+                      const std::string &external_encrypted = "") {
+    this->id_mappings_.push_back(IdMapping{device, external, external_encrypted});
   }
 
  protected:
@@ -70,7 +81,7 @@ class MosquittoBroker : public Component {
   uint32_t connect_begin_{0};
   esp_mqtt_client_handle_t esp_mqtt_client_{nullptr};
   std::vector<MosquittoMessageTrigger *> message_triggers_;
-  std::vector<std::pair<std::string, std::string>> id_mappings_;
+  std::vector<IdMapping> id_mappings_;
 };
 
 template<typename... Ts> class PublishMessageAction : public Action<Ts...> {

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,70 @@
+# Troubleshooting
+
+## The battery doesn't react to commands (e.g. cd=1)
+
+Marsrelay's log shows `Received control message: ...` but the battery never answers: the command reaches Marsrelay but doesn't match the topic the battery listens on. Compare the `.../device/<deviceId>/...` topic the battery publishes on (see [finding your device information](../README.md#3-find-your-device-information)) with the topic your commands arrive on. Two common causes:
+
+**Cause 1: Wrong topic prefix (`hame_energy` vs. `marstek_energy`).** Older firmware uses `hame_energy/...`, newer firmware `marstek_energy/...`. The current example config forwards commands for both, but configs created from an older version only subscribe `marstek_energy/+/App/+/ctrl`. If your battery's `/device/` topics appear under `hame_energy/...`, make sure that prefix is subscribed too in the `mqtt.on_connect` lambda:
+
+```yaml
+mqtt:
+  # ...
+  on_connect:
+    - lambda: |-
+        id(mqtt_client).subscribe("hame_energy/+/App/+/ctrl", [=](const std::string &topic, const std::string &payload) {
+          ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
+          id(local_broker).publish_message(topic, payload);
+        });
+        // keep the existing marstek_energy subscription from the example config here as well
+```
+
+The outgoing direction needs no change: the `mosquitto_broker` `on_message` forwarding matches any topic containing `/device/`, regardless of prefix.
+
+**Cause 2: The device ID in the topic doesn't match what hm2mqtt publishes to.** Newer firmware switches the battery from its plain MAC to an [encrypted ID](../README.md#device-ids-mac-address-vs-encrypted-id) (e.g. Jupiter C+ with firmware v142), so this often shows up right after a firmware update:
+
+- **Venus/Jupiter and other non-B2500 devices:** find the battery's encrypted ID (see [finding the encrypted ID](../README.md#finding-the-encrypted-id)) and either configure it as the `deviceId` in hm2mqtt or add an `id_mappings` entry in Marsrelay.
+- **B2500/Saturn devices (HMA/HMB/HMF/HMK/HMJ):** keep the **Bluetooth MAC** as `deviceId` in hm2mqtt and add an `id_mappings` entry mapping the battery's topic ID to that MAC (requires a current Marsrelay build). If you pasted the battery's topic ID into hm2mqtt instead, that's the problem: commands end up on a double-encrypted topic (~96-character IDs in the Marsrelay log).
+
+## No /device/ topic ever appears
+
+Work through this checklist:
+
+1. **Are you looking at the right topics?** Only `.../device/...` topics come from the battery — `.../App/...` topics are commands *from* hm2mqtt. Watch both the `marstek_energy` and `hame_energy` prefixes.
+2. **Wait long enough.** The battery can take up to 20 minutes to publish. Keep MQTT Explorer connected the whole time.
+3. **Is the battery really connected to the Marsrelay access point?** The Marstek app sometimes reports a successful WiFi change even though the battery didn't connect. When it is connected, the Marsrelay log shows its HTTP requests, e.g. `HTTP GET /app/neng/getDateInfoeu.php`. If those appear but no `/device/` topic does, the problem is on the MQTT side (next points).
+4. **Can Marsrelay reach your home MQTT broker?** Verify `mqtt_broker`, `mqtt_username` and `mqtt_password` in the substitutions, and check the ESPHome logs for MQTT connection errors.
+5. **Is the ESP32 stable?** Watch the logs via USB for a crash loop, and make sure the `psram` settings match your board.
+
+If you only need the device ID while you keep debugging, get it from Hame Relay's startup logs instead of waiting (see [finding the encrypted ID](../README.md#finding-the-encrypted-id)).
+
+## Repeating getDateInfoeu.php requests and UDP proxy log lines
+
+Not a problem — that's healthy operation. `HTTP GET /app/neng/getDateInfoeu.php` is the battery checking in with the (emulated) cloud, and the `udp_proxy` lines are power meter packets being bridged. Two related things that are easy to misread:
+
+- Messages on `<mqtt_topic_prefix>/request` (e.g. `marsrelay/request`) are **diagnostic logs** of the battery's HTTP requests — not battery data.
+- The battery does **not** push telemetry on its own. Data only appears under `.../device/...` when something requests it — which is what [hm2mqtt](https://github.com/tomquist/hm2mqtt) does (e.g. `cd=1`). Without hm2mqtt, seeing nothing but `request` messages is expected.
+
+## Communication stops after a few hours, or the log shows broker crashes
+
+If the log shows `***ERROR*** A stack overflow in task mosq_broker` or `Unable to accept new connection, system socket count has been exceeded`, first update to the latest `main` — earlier versions of the embedded broker had crash bugs that have been fixed. Beyond that:
+
+- Some users report better long-term stability with `CONFIG_LWIP_MAX_SOCKETS: "32"` and `CONFIG_LWIP_SOCKET_OFFSET: "16"` in the `sdkconfig_options`.
+- A power cycle of the ESP32 restores communication as a stopgap.
+- The log line `TLS client: certificate verification relaxed (CN check disabled, ...)` is expected with `tls_skip_verification: true` and is not an error.
+- If crashes persist, double-check the `psram` settings match your board, and consider a standard ESP32-S3 devkit board.
+
+Long-running dropouts where MQTT and UDP stop together while WiFi stays up are still being investigated in [issue #10](https://github.com/tomquist/marsrelay/issues/10).
+
+## The battery can't reach a power meter on my home network (e.g. EcoTracker)
+
+The Marsrelay access point is a separate network, so devices on your home LAN are not directly reachable from the battery. `udp_proxy` bridges exactly one thing: **UDP broadcasts** of the supported meter protocols (Shelly, CT00x). TCP-polled meters — such as the everHome EcoTracker — cannot be bridged this way ([issue #16](https://github.com/tomquist/marsrelay/issues/16)).
+
+Workaround: bring the meter reading into ESPHome as a sensor (e.g. imported from Home Assistant) and serve it to the battery with the [Shelly UDP emulator](../README.md#optional-shelly-udp-emulator) directly on the ESP32.
+
+## hm2mqtt shows all entities as unavailable
+
+hm2mqtt is waiting for data under a `deviceId` that doesn't correspond to what the battery publishes. Check the configured `deviceId` against the ID in the battery's `.../device/<deviceId>/...` topic: for B2500/Saturn devices it must be the Bluetooth MAC plus an `id_mappings` entry mapping the battery's topic ID to that MAC; for all other devices it must match the topic ID exactly (or be connected via `id_mappings`). See [Device IDs](../README.md#device-ids-mac-address-vs-encrypted-id).
+
+## Can I run Marsrelay on a Raspberry Pi instead of an ESP32?
+
+Not with this codebase — it's an ESPHome project. But the concept ports: you'd need a WiFi hotspot, a DNS server that resolves every query to the Pi itself, an HTTP server implementing the Marstek cloud endpoints (see `components/marstack/`), and a TLS-enabled MQTT broker on port 8883 that bridges to your main broker (see `components/mosquitto_broker/`). See [How It Works](../README.md#how-it-works) for how the pieces fit together.

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -11,7 +11,7 @@ substitutions:
   mqtt_topic_prefix: "marsrelay"
   # Timezone used to sync the battery clock (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
   timezone: "Europe/Berlin"
-  # UDP proxy port for power meter discovery (see https://github.com/tomquist/b2500-meter)
+  # UDP proxy port for power meter discovery (see https://github.com/tomquist/AstraMeter)
   # - Port 1010: Shelly Pro 3EM for B2500 firmware up to v224, Jupiter, Venus
   # - Port 2220: Shelly Pro 3EM for B2500 firmware v226+
   # - Port 2222: Shelly 3EM gen3

--- a/marsrelay_esp32s3.yaml
+++ b/marsrelay_esp32s3.yaml
@@ -82,18 +82,22 @@ mqtt:
   password: ${mqtt_password}
   on_connect:
     - lambda: |-
-        id(mqtt_client).subscribe("marstek_energy/+/App/+/ctrl", [=](const std::string &topic, const std::string &payload) {
-          ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
-          if (topic.find("/App/") == std::string::npos) {
-            ESP_LOGD("MQTT", "Not a control message, skipping");
-            return;
-          }
-          if (topic.find("/ctrl") == std::string::npos) {
-            ESP_LOGD("MQTT", "Not a control message, skipping");
-            return;
-          }
-          id(local_broker).publish_message(topic, payload);
-        });
+        // Batteries use the marstek_energy prefix on newer firmware and the
+        // hame_energy prefix on older firmware; forward commands for both.
+        for (const char *pattern : {"marstek_energy/+/App/+/ctrl", "hame_energy/+/App/+/ctrl"}) {
+          id(mqtt_client).subscribe(pattern, [=](const std::string &topic, const std::string &payload) {
+            ESP_LOGD("MQTT", "Received control message: %s", topic.c_str());
+            if (topic.find("/App/") == std::string::npos) {
+              ESP_LOGD("MQTT", "Not a control message, skipping");
+              return;
+            }
+            if (topic.find("/ctrl") == std::string::npos) {
+              ESP_LOGD("MQTT", "Not a control message, skipping");
+              return;
+            }
+            id(local_broker).publish_message(topic, payload);
+          });
+        }
 
 mosquitto_broker:
   id: local_broker

--- a/tests/component_tests/mosquitto_broker/test_id_mappings.py
+++ b/tests/component_tests/mosquitto_broker/test_id_mappings.py
@@ -16,6 +16,10 @@ def test_mosquitto_broker_id_mappings_generation(generate_main):
     assert "aabbccddeeff" in main_cpp
     assert "22222222222222222222222222222222" in main_cpp
     assert "aabbccddee00" in main_cpp
+    # MAC externals also get their encrypted (hm2mqtt marstek_energy) variant
+    # passed to the C++ component.
+    assert "8009eb5b0d30c3286fabbb5f3e705937" in main_cpp
+    assert "88e9406cbd7abae00b8aece0511a16bf" in main_cpp
 
 
 def _validate(mappings):
@@ -39,6 +43,7 @@ def _validate(mappings):
         ("abcd", "App", "reserved"),
         ("ctrl", "abcd", "reserved"),
         ("marstek_energy", "abcd", "reserved"),
+        ("hame_energy", "abcd", "reserved"),
         ("", "abcd", "empty"),
         ("abcd", "", "empty"),
         ("ab/cd", "abcd", "'/'"),
@@ -94,3 +99,40 @@ def test_id_used_on_both_sides_rejected():
                 {"device": "B", "external": "C"},
             ]
         )
+
+
+# AES-128-CBC(zero IV, PKCS7, hex) of "aabbccddeeff" with hm2mqtt's topic id
+# key — independently computed reference vector.
+AABBCCDDEEFF_ENCRYPTED = "8009eb5b0d30c3286fabbb5f3e705937"
+
+
+def test_encrypted_external_id_of_mac():
+    from components.mosquitto_broker import _encrypted_external_id
+
+    assert _encrypted_external_id("aabbccddeeff") == AABBCCDDEEFF_ENCRYPTED
+
+
+def test_encrypted_external_id_of_non_mac():
+    from components.mosquitto_broker import _encrypted_external_id
+
+    assert _encrypted_external_id("22222222222222222222222222222222") == ""
+    assert _encrypted_external_id("not-a-mac") == ""
+    assert _encrypted_external_id("aabbccddeegg") == ""
+
+
+def test_encrypted_external_collision_with_other_device_rejected():
+    from esphome.config_validation import Invalid
+
+    with pytest.raises(Invalid, match="encrypted form"):
+        _validate(
+            [
+                {"device": AABBCCDDEEFF_ENCRYPTED, "external": "112233445566"},
+                {"device": "33333333333333333333333333333333", "external": "aabbccddeeff"},
+            ]
+        )
+
+
+def test_encrypted_external_equal_to_own_device_allowed():
+    # A battery whose topic id already equals hm2mqtt's derived id: the mapping
+    # degrades to a no-op and must be accepted.
+    _validate([{"device": AABBCCDDEEFF_ENCRYPTED, "external": "aabbccddeeff"}])


### PR DESCRIPTION
## Summary

This PR adds support for Marstek batteries that use encrypted device IDs in their MQTT topics (instead of plain Bluetooth MAC addresses) and batteries that publish on the older `hame_energy/...` topic prefix (instead of `marstek_energy/...`). It also improves documentation significantly with troubleshooting guides and device ID mapping instructions.

## Key Changes

**Core functionality:**
- Extended MQTT subscription to forward control commands on both `marstek_energy/+/App/+/ctrl` and `hame_energy/+/App/+/ctrl` patterns, since different firmware generations use different prefixes
- Enhanced `id_mappings` to automatically compute and match the AES-128-CBC encrypted variant of Bluetooth MAC addresses that hm2mqtt derives for B2500 device types on `marstek_energy` topics
- Added logic to select the correct external ID form (plain MAC vs. encrypted variant) based on the topic prefix and device type when translating device→external topics
- Updated reserved ID segments to include `hame_energy` alongside `marstek_energy`

**Configuration and validation:**
- Added Python helper `_encrypted_external_id()` to compute the encrypted MAC variant at codegen time using the same AES key and algorithm as hm2mqtt
- Enhanced `id_mappings` validation to detect collisions in both plain and encrypted forms of external IDs
- Updated `IdMapping` struct to store both `external` (plain MAC) and `external_encrypted` (derived form) for efficient runtime lookup

**Documentation:**
- Completely rewrote "How It Works" section with detailed component descriptions and a Mermaid flowchart showing data flow
- Added comprehensive "Device IDs: MAC Address vs. Encrypted ID" section explaining when each form is used, which device families are affected, and how to configure them
- Added "Troubleshooting" section covering common issues: commands not reaching battery, missing `/device/` topics, stability problems, power meter connectivity, and more
- Clarified the relationship between Marsrelay, hm2mqtt, and Hame Relay with a comparison table
- Updated references from `b2500-meter` to `AstraMeter` (the project's new name)
- Added detailed instructions for finding encrypted device IDs via MQTT Explorer or Hame Relay logs

## Implementation Details

The encrypted ID support works by:
1. At config validation time, computing the AES-128-CBC(zero IV, PKCS7) encrypted form of any Bluetooth MAC in `id_mappings`
2. Storing both forms in the `IdMapping` struct
3. At runtime, when translating topics:
   - Device→external: checking if the topic uses `marstek_energy` prefix and a B2500 device type, then selecting the encrypted form if available
   - External→device: accepting either the plain MAC or encrypted variant as a match, so configs work regardless of which form is present

This allows users to configure `id_mappings` with just the plain Bluetooth MAC (the familiar form), while still correctly matching hm2mqtt's encrypted topic IDs on `marstek_energy` topics for B2500 devices. The mapping degrades to a no-op when a battery's topic ID already equals the encrypted variant.

https://claude.ai/code/session_01RtxsD11TmwbY1AYNKJxgmb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encrypted device identifiers derived from Bluetooth MAC addresses.
  * Added support for control messages using both Marstek Energy and Hame Energy topics.
  * Added an offline setup guide with device configuration instructions and diagrams.

* **Bug Fixes**
  * Prevented ambiguous or conflicting device ID mappings.

* **Documentation**
  * Added a troubleshooting guide covering MQTT, connectivity, device mapping, and broker issues.
  * Added an MIT license and linked license information from the README.

* **Tests**
  * Expanded coverage for encrypted identifiers, validation, and reserved topic names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->