### PR TITLE
docs: add Marstek ecosystem project family table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Marsrelay runs your Marstek Energy Storage system **completely offline**: a smal
 - **No device hacking** — you only point the battery's WiFi at Marsrelay's access point
 - **Home Assistant integration** via [hm2mqtt](https://github.com/tomquist/hm2mqtt)
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| [hm2mqtt](https://github.com/tomquist/hm2mqtt) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| [hame-relay](https://github.com/tomquist/hame-relay) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| **marsrelay** (this repo) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| [AstraMeter](https://github.com/tomquist/astrameter) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| [hmjs](https://github.com/tomquist/hmjs) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| [esphome-b2500](https://github.com/tomquist/esphome-b2500) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 ## How It Works
 
 Marstek batteries talk to two cloud services: an HTTP API and an MQTT broker. Marsrelay emulates both on one ESP32-S3:


### PR DESCRIPTION
Add a structured overview of the Marstek open-source tools ecosystem to the README, helping users discover related projects and understand how Marsrelay fits into the broader tooling landscape.

**Changes:**
- Added a new "Marstek ecosystem" section with a table listing six related projects (hm2mqtt, hame-relay, AstraMeter, hmjs, esphome-b2500)
- Each project includes a brief description of its purpose and how it relates to Marsrelay
- Section is wrapped in HTML comments (`marstek-family:start/end`) to enable automated synchronization across the ecosystem repositories

This makes it easier for users to find complementary tools and understand the full range of options available for working with Marstek batteries.

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new README section describing the Marstek ecosystem.
  * Included an overview table of related open-source battery tools and their functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->